### PR TITLE
(null) origin requests option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ You may optionally specify these options in settings.py to override the defaults
 
         CORS_ALLOW_CREDENTIALS = False
 
+>CORS\_ORIGIN\_ALLOW\_NULL: specify if an empty origin sent by Cordova/PhoneGap or file:// hosted HTML file is allowed
+
+    Default:
+
+        CORS_ALLOW_NULL = False
+
 ## Changelog ##
 v0.13 and onwards - [Release Notes](https://github.com/ottoyiu/django-cors-headers/releases)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You may optionally specify these options in settings.py to override the defaults
 
     Default:
 
-        CORS_ALLOW_NULL = False
+        CORS_ORIGIN_ALLOW_NULL = False
 
 ## Changelog ##
 v0.13 and onwards - [Release Notes](https://github.com/ottoyiu/django-cors-headers/releases)

--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -35,3 +35,5 @@ CORS_EXPOSE_HEADERS = getattr(settings, 'CORS_EXPOSE_HEADERS', ())
 CORS_URLS_REGEX = getattr(settings, 'CORS_URLS_REGEX', '^.*$')
 
 CORS_MODEL = getattr(settings, 'CORS_MODEL', None)
+
+CORS_ORIGIN_NULL_ALLOWED = getattr(settings, 'CORS_ORIGIN_ALLOW_NULL', False)

--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -36,4 +36,4 @@ CORS_URLS_REGEX = getattr(settings, 'CORS_URLS_REGEX', '^.*$')
 
 CORS_MODEL = getattr(settings, 'CORS_MODEL', None)
 
-CORS_ORIGIN_NULL_ALLOWED = getattr(settings, 'CORS_ORIGIN_ALLOW_NULL', False)
+CORS_ORIGIN_ALLOW_NULL = getattr(settings, 'CORS_ORIGIN_ALLOW_NULL', False)

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -67,6 +67,8 @@ class CorsMiddleware(object):
         return response
 
     def origin_not_found_in_white_lists(self, origin, url):
+        if (url.netloc == '') and (settings.CORS_ORIGIN_ALLOW_NULL == True):
+            return false
         return url.netloc not in settings.CORS_ORIGIN_WHITELIST and not self.regex_domain_match(origin)
 
     def regex_domain_match(self, origin):


### PR DESCRIPTION
Hi, i could not get (null) origin to work with any regexp, so i added this option.
This is used if phonegap-like application is making the requests.
