### PR TITLE
allow all origins for a specified URL patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ You may optionally specify these options in settings.py to override the defaults
 
         CORS_REPLACE_HTTPS_REFERER = False
 
+>CORS\_URLS\_ALLOW\_ALL\_REGEX: specify a list of URL regex for which to allow all origins
+
+    Example:
+
+        CORS_URLS_ALLOW_ALL_REGEX = (r'^/api/users$', )
+
+    Default:
+
+        CORS_URLS_ALLOW_ALL_REGEX = ()
+
 ## Changelog ##
 v0.13 and onwards - [Release Notes](https://github.com/ottoyiu/django-cors-headers/releases)
 

--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -46,3 +46,4 @@ CORS_REPLACE_HTTPS_REFERER = getattr(
     settings,
     'CORS_REPLACE_HTTPS_REFERER',
     False)
+CORS_URLS_ALLOW_ALL_REGEX = getattr(settings, 'CORS_URLS_ALLOW_ALL_REGEX', ())

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -114,7 +114,8 @@ class CorsMiddleware(object):
                     response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
 
             if (not settings.CORS_ORIGIN_ALLOW_ALL and
-                    self.origin_not_found_in_white_lists(origin, url)):
+                    self.origin_not_found_in_white_lists(origin, url) and
+                    not self.regex_url_allow_all_match(request.path)):
                 return response
 
             response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*" if (
@@ -149,4 +150,10 @@ class CorsMiddleware(object):
                 return origin
 
     def is_enabled(self, request):
-        return re.match(settings.CORS_URLS_REGEX, request.path)
+        return re.match(settings.CORS_URLS_REGEX, request.path) or \
+            self.regex_url_allow_all_match(request.path)
+
+    def regex_url_allow_all_match(self, path):
+        for url_pattern in settings.CORS_URLS_ALLOW_ALL_REGEX:
+            if re.match(url_pattern, path):
+                return path

--- a/corsheaders/tests.py
+++ b/corsheaders/tests.py
@@ -335,3 +335,25 @@ class TestCorsMiddlewareProcessResponse(TestCase):
         request = Mock(path='/', META={'HTTP_ORIGIN': 'http://foo.google.com'})
         processed = self.middleware.process_response(request, response)
         self.assertEqual(processed.get(ACCESS_CONTROL_ALLOW_ORIGIN, None), 'http://foo.google.com')
+
+    def test_process_response_in_allow_all_path(self, settings):
+        settings.CORS_MODEL = None
+        settings.CORS_ORIGIN_ALLOW_ALL = False
+        # settings.CORS_ORIGIN_WHITELIST = ['example.com', 'foobar.it']
+        settings.CORS_URLS_REGEX = '^.*$'
+        settings.CORS_URLS_ALLOW_ALL_REGEX = (r'^/api/.*$',)
+        response = HttpResponse()
+        request = Mock(path='/api/data', META={'HTTP_ORIGIN': 'http://foobar.it'})
+        processed = self.middleware.process_response(request, response)
+        self.assertAccessControlAllowOriginEquals(processed, 'http://foobar.it')
+
+    def test_process_response_not_in_allow_all_path(self, settings):
+        settings.CORS_MODEL = None
+        settings.CORS_ORIGIN_ALLOW_ALL = False
+        # settings.CORS_ORIGIN_WHITELIST = ['example.com', 'foobar.it']
+        settings.CORS_URLS_REGEX = '^.*$'
+        settings.CORS_URLS_ALLOW_ALL_REGEX = (r'^/api/.*$',)
+        response = HttpResponse()
+        request = Mock(path='/data', META={'HTTP_ORIGIN': 'http://foobar.it'})
+        processed = self.middleware.process_response(request, response)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, processed)


### PR DESCRIPTION
This allows you specify a URL pattern to allow all origins, the whitelist will still be applicable to all other paths.