### PR TITLE
Django 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
  - DJANGO_VERSION="Django==1.5.10"
  - DJANGO_VERSION="Django==1.6.7"
  - DJANGO_VERSION="Django==1.7.0"
+ - DJANGO_VERSION="Django==1.8.0"
 
 matrix:
     exclude:
@@ -29,6 +30,8 @@ matrix:
           env: DJANGO_VERSION="Django==1.4.15"
         - python: 2.6
           env: DJANGO_VERSION="Django==1.7.0"
+        - python: 2.6
+          env: DJANGO_VERSION="Django==1.8.0"
 
 install:
   - pip install -q $DJANGO_VERSION

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -6,8 +6,13 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
+try:
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models.loading import get_model
+
 from corsheaders import defaults as settings
-from django.db.models.loading import get_model
 
 
 ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'

--- a/tests.py
+++ b/tests.py
@@ -24,9 +24,12 @@ def run_tests():
     if hasattr(django, 'setup'):
         django.setup()
 
-    from django.test.simple import DjangoTestSuiteRunner
+    try:
+        from django.test.runner import DiscoverRunner as Runner
+    except ImportError:
+        from django.test.simple import DjangoTestSuiteRunner as Runner
 
-    test_runner = DjangoTestSuiteRunner(verbosity=1)
+    test_runner = Runner(verbosity=1)
     return test_runner.run_tests(['corsheaders'])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,15 +10,19 @@ envlist =
     py27-django15,
     py27-django16,
     py27-django17,
+    py27-django18,
     py32-django15,
     py32-django16,
     py32-django17,
+    py32-django18,
     py33-django15,
     py33-django16,
     py33-django17,
+    py33-django18,
     py34-django15,
     py34-django16,
     py34-django17,
+    py34-django18,
 
 [testenv]
 commands = python setup.py test
@@ -37,6 +41,9 @@ deps = django == 1.6.7
 
 [django17]
 deps = django == 1.7.0
+
+[django18]
+deps = django == 1.8.0
 
 [testenv:py26-django13]
 basepython = python2.6
@@ -75,6 +82,10 @@ deps = {[django16]deps}
 basepython = python2.7
 deps = {[django17]deps}
 
+[testenv:py27-django18]
+basepython = python2.7
+deps = {[django18]deps}
+
 
 [testenv:py32-django15]
 basepython = python3.2
@@ -87,6 +98,10 @@ deps = {[django16]deps}
 [testenv:py32-django17]
 basepython = python3.2
 deps = {[django17]deps}
+
+[testenv:py32-django18]
+basepython = python3.2
+deps = {[django18]deps}
 
 
 [testenv:py33-django15]
@@ -101,6 +116,10 @@ deps = {[django16]deps}
 basepython = python3.3
 deps = {[django17]deps}
 
+[testenv:py33-django18]
+basepython = python3.3
+deps = {[django18]deps}
+
 
 [testenv:py34-django15]
 basepython = python3.4
@@ -113,3 +132,7 @@ deps = {[django16]deps}
 [testenv:py34-django17]
 basepython = python3.4
 deps = {[django17]deps}
+
+[testenv:py34-django18]
+basepython = python3.3
+deps = {[django14]deps}


### PR DESCRIPTION
- Add Django 1.8.0 to tox and travis.
- Fix `RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.`
- Fix test runner.