### PR TITLE
Update get_model() import for django 1.9

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -10,7 +10,10 @@ try:
     from django.apps import apps
     get_model = apps.get_model
 except ImportError:
-    from django.db.models.loading import get_model
+    try:
+        from django.db.models.loading import get_model
+    except ImportError:
+        from django.apps.apps.get_model import get_model
 
 from corsheaders import defaults as settings
 


### PR DESCRIPTION
This work in my fork but I only test it with Django 1.9.