### PR TITLE
Add support for a list of URL regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ You may optionally specify these options in settings.py to override the defaults
 
         CORS_URLS_REGEX = '^.*$'
 
+>CORS\_URLS\_REGEX\_WHITELIST: specify a regex list of URLs for which to enable the sending of CORS headers, regardless the origin of the request; Useful to be combined with `CORS\_URLS\_REGEX` and `CORS_ORIGIN_WHITELIST` to support more complex scenarios.
+
+    Example:
+
+        CORS\_URLS\_REGEX\_WHITELIST = (
+            r'^/api/resource1/.*$',
+            r'^/api/resource2/.*$'
+        )
+
+    Default:
+
+        CORS\_URLS\_REGEX\_WHITELIST = ()
+
 >CORS\_ALLOW\_METHODS: specify the allowed HTTP methods that can be used when making the actual request
 
     Default:

--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -40,6 +40,8 @@ CORS_EXPOSE_HEADERS = getattr(settings, 'CORS_EXPOSE_HEADERS', ())
 
 CORS_URLS_REGEX = getattr(settings, 'CORS_URLS_REGEX', '^.*$')
 
+CORS_URLS_REGEX_WHITELIST = getattr(settings, 'CORS_URLS_REGEX_WHITELIST', ())
+
 CORS_MODEL = getattr(settings, 'CORS_MODEL', None)
 
 CORS_REPLACE_HTTPS_REFERER = getattr(

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -114,6 +114,7 @@ class CorsMiddleware(object):
                     response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
 
             if (not settings.CORS_ORIGIN_ALLOW_ALL and
+                    self.resource_not_found_in_white_lists(request) and
                     self.origin_not_found_in_white_lists(origin, url)):
                 return response
 
@@ -142,6 +143,12 @@ class CorsMiddleware(object):
     def origin_not_found_in_white_lists(self, origin, url):
         return (url.netloc not in settings.CORS_ORIGIN_WHITELIST and
                 not self.regex_domain_match(origin))
+
+    def resource_not_found_in_white_lists(self, request):
+        for regex in settings.CORS_URLS_REGEX_WHITELIST:
+            if re.match(regex, request.path):
+                return False
+        return True
 
     def regex_domain_match(self, origin):
         for domain_pattern in settings.CORS_ORIGIN_REGEX_WHITELIST:

--- a/corsheaders/tests.py
+++ b/corsheaders/tests.py
@@ -211,6 +211,17 @@ class TestCorsMiddlewareProcessResponse(TestCase):
         processed = self.middleware.process_response(request, response)
         self.assertAccessControlAllowOriginEquals(processed, 'http://foobar.it')
 
+    def test_process_response_not_in_whitelist_but_in_url_whitelist(self, settings):
+        settings.CORS_MODEL = None
+        settings.CORS_ORIGIN_ALLOW_ALL = False
+        settings.CORS_ORIGIN_WHITELIST = ['example.com']
+        settings.CORS_URLS_REGEX = '^.*$'
+        settings.CORS_URLS_REGEX_WHITELIST = ['^/api/.*$']
+        response = HttpResponse()
+        request = Mock(path='/api/', META={'HTTP_ORIGIN': 'http://foobar.it'})
+        processed = self.middleware.process_response(request, response)
+        self.assertAccessControlAllowOriginEquals(processed, 'http://foobar.it')
+
     def test_process_response_expose_headers(self, settings):
         settings.CORS_MODEL = None
         settings.CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
Dear @ottoyiu 

In order to support more complex authorization scenarios, I had to add a new setting in your CORS Django library. Hope you find it useful and accept it as a pull request.

Here is the complete description of my contribution:

> A new setting was added to allow for the activation of CORS for certain URL patterns,
> regardless of the request origin. This can be combined with the current available
> settings to support more complex authorization scenarios.
> 
> Documentation and tests have been also included to give more insight into the setting.

Regards,