### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ matrix:
 
 install:
   - pip install -q $DJANGO_VERSION
-  - pip install . --use-mirrors
-  - pip install "flake8>=2.2.5"
-  - pip install "coverage>=3.7.1"
+  - pip install .
+  - pip install "flake8>=2.2.5,<3.0"
+  - pip install "coverage>=3.7.1,<4"
 
 script:
   - flake8 --config flake8.cfg .


### PR DESCRIPTION
As discovered in the build for #111, it's broken because `pip` no longer has the `--use-mirrors` option.

Also the latest `flake8` and `coverage` versions don't support Pythons 2.6 and 3.2 respectively. We should drop these, 3.2 at least.