### PR TITLE
Put changelog into file, post on PyPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,74 @@
+History
+=======
+
+1.1.0 (2014-12-15)
+------------------
+
+* django-cors-header now supports Django 1.8 with its new application loading
+  system! Thanks @jpadilla for making this possible and sorry for the delay in
+  making a release.
+
+1.0.0 (2014-12-13)
+------------------
+
+django-cors-headers is all grown-up :) Since it's been used in production for
+many many deployments, I think it's time we mark this as a stable release.
+
+* Switching this middleware versioning over to semantic versioning
+* #46 add user-agent and accept-encoding default headers
+* #45 pep-8 this big boy up
+
+0.13 (2014-08-14)
+-----------------
+
+* Add support for Python 3
+* Updated tests
+* Improved docuemntation
+* Small bugfixes
+
+0.12 (2013-09-24)
+-----------------
+
+* Added an option to selectively enable CORS only for specific URLs
+
+0.11 (2013-09-24)
+
+* Added the ability to specify a regex for whitelisting many origin hostnames
+  at once
+
+0.10 (2013-09-05)
+-----------------
+
+* Introduced port distinction for origin checking
+* Use ``urlparse`` for Python 3 support
+* Added testcases to project
+
+0.06 (2013-02-18)
+-----------------
+
+* Add support for exposed response headers
+
+0.05 (2013-01-26)
+-----------------
+
+* Fixed middleware to ensure correct response for CORS preflight requests
+
+0.04 (2013-01-25)
+-----------------
+
+* Add ``Access-Control-Allow-Credentials`` control to simple requests
+
+0.03 (2013-01-22)
+-----------------
+
+* Bugfix to repair mismatched default variable names
+
+0.02 (2013-01-19)
+-----------------
+
+* Refactor/pull defaults into separate file
+
+0.01 (2013-01-19)
+-----------------
+
+* Initial release

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst
+include HISTORY.rst README.rst
 include LICENSE.txt

--- a/README.rst
+++ b/README.rst
@@ -177,35 +177,6 @@ pass, so that the Django CSRF middleware checks work with HTTPS. Defaults to
 ``django.middleware.csrf.CsrfViewMiddleware`` in your ``MIDDLEWARE_CLASSES`` to
 undo the header replacement.
 
-
-Changelog
----------
-
-v0.13 and onwards - `Release
-Notes <https://github.com/ottoyiu/django-cors-headers/releases>`__
-
-v0.12 - Added an option to selectively enable CORS only for specific
-URLs
-
-v0.11 - Added the ability to specify a regex for whitelisting many
-origin hostnames at once
-
-v0.10 - Introduced port distinction for origin checking; use
-``urlparse`` for Python 3 support; added testcases to project
-
-v0.06 - Add support for exposed response headers
-
-v0.05 - fixed middleware to ensure correct response for CORS preflight
-requests
-
-v0.04 - add Access-Control-Allow-Credentials control to simple requests
-
-v0.03 - bugfix (repair mismatched default variable names)
-
-v0.02 - refactor/pull defaults into separate file
-
-v0.01 - initial release
-
 Credits
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,14 @@ from setuptools import setup
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
+with open('HISTORY.rst') as history_file:
+    history = history_file.read()
+
 setup(
     name='django-cors-headers',
     version=__version__,
     description='django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS).',
-    long_description=readme,
+    long_description=readme + '\n\n' + history,
     author='Otto Yiu',
     author_email='otto@live.ca',
     url='https://github.com/ottoyiu/django-cors-headers',


### PR DESCRIPTION
Having an easy to find changelog is important. We make it as visible as possible here by both having it in a separate file and posting it in the `long_description` on PyPI. It's now filled with the release notes that were on Github releases, which is a somewhat non-obvious place since most projects don't use them.