### PR TITLE
Update tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-downloadcache = {toxworkdir}/cache/
 envlist =
     py26-django13,
     py26-django14,
@@ -28,111 +27,89 @@ envlist =
 commands = python setup.py test
 
 [django13]
-deps = django == 1.3.7
+deps = Django>=1.3.0,<1.4.0
 
 [django14]
-deps = django == 1.4.15
+deps = Django>=1.4.0,<1.5.0
 
 [django15]
-deps = django == 1.5.10
+deps = Django>=1.5.0,<1.6.0
 
 [django16]
-deps = django == 1.6.7
+deps = Django>=1.6.0,<1.7.0
 
 [django17]
-deps = django == 1.7.0
+deps = Django>=1.7.0,<1.8.0
 
 [django18]
-deps = django == 1.8.0
+deps = Django>=1.8.0,<1.9.0
 
 [testenv:py26-django13]
-basepython = python2.6
 deps = {[django13]deps}
 
 [testenv:py26-django14]
-basepython = python2.6
 deps = {[django14]deps}
 
 [testenv:py26-django15]
-basepython = python2.6
 deps = {[django15]deps}
 
 [testenv:py26-django16]
-basepython = python2.6
 deps = {[django16]deps}
 
 
 [testenv:py27-django13]
-basepython = python2.7
 deps = {[django13]deps}
 
 [testenv:py27-django14]
-basepython = python2.7
 deps = {[django14]deps}
 
 [testenv:py27-django15]
-basepython = python2.7
 deps = {[django15]deps}
 
 [testenv:py27-django16]
-basepython = python2.7
 deps = {[django16]deps}
 
 [testenv:py27-django17]
-basepython = python2.7
 deps = {[django17]deps}
 
 [testenv:py27-django18]
-basepython = python2.7
 deps = {[django18]deps}
 
 
 [testenv:py32-django15]
-basepython = python3.2
 deps = {[django15]deps}
 
 [testenv:py32-django16]
-basepython = python3.2
 deps = {[django16]deps}
 
 [testenv:py32-django17]
-basepython = python3.2
 deps = {[django17]deps}
 
 [testenv:py32-django18]
-basepython = python3.2
 deps = {[django18]deps}
 
 
 [testenv:py33-django15]
-basepython = python3.3
 deps = {[django15]deps}
 
 [testenv:py33-django16]
-basepython = python3.3
 deps = {[django16]deps}
 
 [testenv:py33-django17]
-basepython = python3.3
 deps = {[django17]deps}
 
 [testenv:py33-django18]
-basepython = python3.3
 deps = {[django18]deps}
 
 
 [testenv:py34-django15]
-basepython = python3.4
 deps = {[django15]deps}
 
 [testenv:py34-django16]
-basepython = python3.4
 deps = {[django16]deps}
 
 [testenv:py34-django17]
-basepython = python3.4
 deps = {[django17]deps}
 
 [testenv:py34-django18]
-basepython = python3.3
 deps = {[django14]deps}


### PR DESCRIPTION
* Add in the Django version checking from #75
* Remove the unnecessary `downloadcache` and `basepython` options