### PR TITLE
Confirm Django 1.9 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,8 +4,9 @@ History
 Pending
 -------
 
-* Drop Python 2.6 support
+* Drop Python 2.6 support.
 * Drop Django 1.3-1.7 support, as they are no longer supported.
+* Confirmed Django 1.9 support (no changes outside of tests were necessary).
 
 1.1.0 (2014-12-15)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -44,12 +44,12 @@ You will also need to add a middleware class to listen in on responses:
 
 .. code-block:: python
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE_CLASSES = [
         ...
         'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',
         ...
-    )
+    ]
 
 Note that ``CorsMiddleware`` needs to come before Django's
 ``CommonMiddleware`` if you are using Django's ``USE_ETAGS = True``

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -6,11 +6,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-try:
-    from django.apps import apps
-    get_model = apps.get_model
-except ImportError:
-    from django.db.models.loading import get_model
+from django.apps import apps
 
 from corsheaders import defaults as settings
 
@@ -109,7 +105,7 @@ class CorsMiddleware(object):
             url = urlparse(origin)
 
             if settings.CORS_MODEL is not None:
-                model = get_model(*settings.CORS_MODEL.split('.'))
+                model = apps.get_model(*settings.CORS_MODEL.split('.'))
                 if model.objects.filter(cors=url.netloc).exists():
                     response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests.py
+++ b/tests.py
@@ -6,8 +6,12 @@ import sys
 
 def run_tests():
     import django
-    from django.conf import global_settings
-    from django.conf import settings
+    from django.conf import global_settings, settings
+    from django.test.runner import DiscoverRunner
+
+    middleware = list(global_settings.MIDDLEWARE_CLASSES)
+    middleware.append('corsheaders.middleware.CorsMiddleware')
+
     settings.configure(
         INSTALLED_APPS=[
             'corsheaders',
@@ -18,18 +22,11 @@ def run_tests():
                 'TEST_NAME': ':memory:',
             },
         },
-        MIDDLEWARE_CLASSES=global_settings.MIDDLEWARE_CLASSES + (
-            'corsheaders.middleware.CorsMiddleware',),
+        MIDDLEWARE_CLASSES=middleware,
     )
-    if hasattr(django, 'setup'):
-        django.setup()
+    django.setup()
 
-    try:
-        from django.test.runner import DiscoverRunner as Runner
-    except ImportError:
-        from django.test.simple import DjangoTestSuiteRunner as Runner
-
-    test_runner = Runner(verbosity=1)
+    test_runner = DiscoverRunner(verbosity=1)
     return test_runner.run_tests(['corsheaders'])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,35}-django{18}
+    py{27,35}-django{18,19}
 
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
 commands = python setup.py test
 
 [testenv:py27-codestyle]


### PR DESCRIPTION
Fixes #118. Uses some of the changes from zestedesavoir/django-cors-middleware#18.