### PR TITLE
Add Django 1.10 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending
 * Drop Python 2.6 support.
 * Drop Django 1.3-1.7 support, as they are no longer supported.
 * Confirmed Django 1.9 support (no changes outside of tests were necessary).
+* Added Django 1.10 support.
 * Package as a universal wheel.
 
 1.1.0 (2014-12-15)

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Requirements
 Tested with all combinations of:
 
 * Python: 2.7, 3.5
-* Django: 1.8
+* Django: 1.8, 1.9, 1.10
 
 Setup
 -----

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -8,6 +8,11 @@ except ImportError:
 
 from django.apps import apps
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 from corsheaders import defaults as settings
 
 
@@ -19,7 +24,7 @@ ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods'
 ACCESS_CONTROL_MAX_AGE = 'Access-Control-Max-Age'
 
 
-class CorsPostCsrfMiddleware(object):
+class CorsPostCsrfMiddleware(MiddlewareMixin):
 
     def _https_referer_replace_reverse(self, request):
         """
@@ -41,7 +46,7 @@ class CorsPostCsrfMiddleware(object):
         return None
 
 
-class CorsMiddleware(object):
+class CorsMiddleware(MiddlewareMixin):
 
     def _https_referer_replace(self, request):
         """

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -13,6 +13,13 @@ try:
 except ImportError:
     MiddlewareMixin = object
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
 from corsheaders import defaults as settings
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests.py
+++ b/tests.py
@@ -9,21 +9,28 @@ def run_tests():
     from django.conf import global_settings, settings
     from django.test.runner import DiscoverRunner
 
+    if django.VERSION >= (1, 10):
+        middleware_setting = 'MIDDLEWARE'
+    else:
+        middleware_setting = 'MIDDLEWARE_CLASSES'
+
     middleware = list(global_settings.MIDDLEWARE_CLASSES)
     middleware.append('corsheaders.middleware.CorsMiddleware')
 
-    settings.configure(
-        INSTALLED_APPS=[
+    config = {
+        'INSTALLED_APPS': [
             'corsheaders',
         ],
-        DATABASES={
+        'DATABASES': {
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
                 'TEST_NAME': ':memory:',
             },
         },
-        MIDDLEWARE_CLASSES=middleware,
-    )
+        'ROOT_URLCONF': 'corsheaders.tests',
+        middleware_setting: middleware,
+    }
+    settings.configure(**config)
     django.setup()
 
     test_runner = DiscoverRunner(verbosity=1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,35}-django{18,19}
+    py{27,35}-django{18,19,110}
 
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
 commands = python setup.py test
 
 [testenv:py27-codestyle]


### PR DESCRIPTION
Pull in @fanhan's work from #108 plus @edmorley's work from zestedesavoir/django-cors-middleware#18 and zestedesavoir/django-cors-middleware#19 to add and properly test Django 1.10 support.