### PR TITLE
Dynamically respond to settings changes

### DIFF
--- a/corsheaders/conf.py
+++ b/corsheaders/conf.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+
+from .defaults import default_headers, default_methods  # Kept here for backwards compatibility
+
+
+class Settings(object):
+    """
+    Shadow Django's settings with a little logic
+    """
+
+    @property
+    def CORS_ALLOW_HEADERS(self):
+        return getattr(settings, 'CORS_ALLOW_HEADERS', default_headers)
+
+    @property
+    def CORS_ALLOW_METHODS(self):
+        return getattr(settings, 'CORS_ALLOW_METHODS', default_methods)
+
+    @property
+    def CORS_ALLOW_CREDENTIALS(self):
+        return getattr(settings, 'CORS_ALLOW_CREDENTIALS', False)
+
+    @property
+    def CORS_PREFLIGHT_MAX_AGE(self):
+        return getattr(settings, 'CORS_PREFLIGHT_MAX_AGE', 86400)
+
+    @property
+    def CORS_ORIGIN_ALLOW_ALL(self):
+        return getattr(settings, 'CORS_ORIGIN_ALLOW_ALL', False)
+
+    @property
+    def CORS_ORIGIN_WHITELIST(self):
+        return getattr(settings, 'CORS_ORIGIN_WHITELIST', ())
+
+    @property
+    def CORS_ORIGIN_REGEX_WHITELIST(self):
+        return getattr(settings, 'CORS_ORIGIN_REGEX_WHITELIST', ())
+
+    @property
+    def CORS_EXPOSE_HEADERS(self):
+        return getattr(settings, 'CORS_EXPOSE_HEADERS', ())
+
+    @property
+    def CORS_URLS_REGEX(self):
+        return getattr(settings, 'CORS_URLS_REGEX', r'^.*$')
+
+    @property
+    def CORS_MODEL(self):
+        return getattr(settings, 'CORS_MODEL', None)
+
+    @property
+    def CORS_REPLACE_HTTPS_REFERER(self):
+        return getattr(settings, 'CORS_REPLACE_HTTPS_REFERER', False)
+
+corsheaders_settings = Settings()

--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 default_headers = (
     'x-requested-with',
     'content-type',
@@ -11,8 +9,6 @@ default_headers = (
     'accept-encoding',
 )
 
-CORS_ALLOW_HEADERS = getattr(settings, 'CORS_ALLOW_HEADERS', default_headers)
-
 default_methods = (
     'GET',
     'POST',
@@ -21,28 +17,3 @@ default_methods = (
     'DELETE',
     'OPTIONS',
 )
-CORS_ALLOW_METHODS = getattr(settings, 'CORS_ALLOW_METHODS', default_methods)
-
-CORS_ALLOW_CREDENTIALS = getattr(settings, 'CORS_ALLOW_CREDENTIALS', False)
-
-CORS_PREFLIGHT_MAX_AGE = getattr(settings, 'CORS_PREFLIGHT_MAX_AGE', 86400)
-
-CORS_ORIGIN_ALLOW_ALL = getattr(settings, 'CORS_ORIGIN_ALLOW_ALL', False)
-
-CORS_ORIGIN_WHITELIST = getattr(settings, 'CORS_ORIGIN_WHITELIST', ())
-
-CORS_ORIGIN_REGEX_WHITELIST = getattr(
-    settings,
-    'CORS_ORIGIN_REGEX_WHITELIST',
-    ())
-
-CORS_EXPOSE_HEADERS = getattr(settings, 'CORS_EXPOSE_HEADERS', ())
-
-CORS_URLS_REGEX = getattr(settings, 'CORS_URLS_REGEX', '^.*$')
-
-CORS_MODEL = getattr(settings, 'CORS_MODEL', None)
-
-CORS_REPLACE_HTTPS_REFERER = getattr(
-    settings,
-    'CORS_REPLACE_HTTPS_REFERER',
-    False)

--- a/corsheaders/tests/test_conf.py
+++ b/corsheaders/tests/test_conf.py
@@ -1,0 +1,11 @@
+from django.test.utils import override_settings
+from django.test import SimpleTestCase
+
+from corsheaders.conf import corsheaders_settings
+
+
+class ConfTests(SimpleTestCase):
+
+    @override_settings(CORS_ALLOW_HEADERS=['foo'])
+    def test_can_override(self):
+        assert corsheaders_settings.CORS_ALLOW_HEADERS == ['foo']

--- a/corsheaders/tests/urls.py
+++ b/corsheaders/tests/urls.py
@@ -1,0 +1,16 @@
+from django.conf.urls import url
+from django.http import HttpResponse
+
+
+def test_view(request):
+    return HttpResponse("Test view")
+
+
+def test_view_http401(request):
+    return HttpResponse('Unauthorized', status=401)
+
+
+urlpatterns = [
+    url(r'^test-view/$', test_view, name='test-view'),
+    url(r'^test-view-http401/$', test_view_http401, name='test-view-http401'),
+]

--- a/tests.py
+++ b/tests.py
@@ -27,7 +27,7 @@ def run_tests():
                 'TEST_NAME': ':memory:',
             },
         },
-        'ROOT_URLCONF': 'corsheaders.tests',
+        'ROOT_URLCONF': 'corsheaders.tests.urls',
         middleware_setting: middleware,
     }
     settings.configure(**config)


### PR DESCRIPTION
Fixes #122. This refactors all the settings from `defaults` to the `conf.corsheaders_settings` object, where they dynamically read from Django's settings, allowing changes from e.g. `@override_settings` to take effect. This also means all the tests needed refactoring to use `@override_settings` instead of the previous direct attribute setting /`settings_override` helper.