### PR TITLE
Add a signal that enables CORS headers.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Pending
 
 * New release notes go here.
 * Add ``CorsModel.__str__`` for human-readable text
+* Add a signal that allows you to add code for more intricate control over when
+  CORS headers are added.
 
 1.2.1 (2016-09-30)
 ------------------

--- a/corsheaders/signals.py
+++ b/corsheaders/signals.py
@@ -1,0 +1,6 @@
+from django.dispatch import Signal
+
+# If any attached handler returns Truthy, CORS will be allowed for the request.
+# This can be used to build custom logic into the request handling when the
+# configuration doesn't work.
+check_request_enabled = Signal(providing_args=['request'])


### PR DESCRIPTION
This pulls in @ericholscher's code from zestedesavoir/django-cors-middleware#21 , rebased for the recent changes, and with an improved description and tests.