### PR TITLE
Replace mock requests in tests with real requests

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 docutils
 flake8
 isort
-mock
 multilint
 pytest
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,16 +8,12 @@ configparser==3.5.0       # via flake8
 docutils==0.12
 enum34==1.1.6             # via flake8
 flake8==3.0.4
-funcsigs==1.0.2           # via mock
 isort==4.2.5
 mccabe==0.5.2             # via flake8
-mock==2.0.0
 multilint==2.0.0
-pbr==1.10.0               # via mock
 py==1.4.31                # via pytest
 pycodestyle==2.0.0        # via flake8
 pyflakes==1.2.3           # via flake8
 Pygments==2.1.3
 pytest-django==3.0.0
 pytest==3.0.3
-six==1.10.0               # via mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ max-line-length = 120
 
 [isort]
 known_first_party = corsheaders
-known_third_party = django,mock
+known_third_party = django
 line_length = 120
 multi_line_output = 5
 not_skip = __init__.py


### PR DESCRIPTION
Django's `RequestFactory` provides a neat way of making actual `HttpRequest` objects, so we should use that.