### PR TITLE
Add 'Origin' to 'Vary' header of CORS responses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending
 * Add checks to validate the types of the settings.
 * Add the 'Do Not Track' header ``'DNT'`` to the default for
   ``CORS_ALLOW_HEADERS``.
+* Add 'Origin' to the 'Vary' header of outgoing requests when not allowing all
+  origins, as per the CORS spec. Note this changes the way HTTP caching works
+  with your CORS-enabled responses.
 
 1.2.2 (2016-10-05)
 ------------------

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -2,6 +2,7 @@ import re
 
 from django import http
 from django.apps import apps
+from django.utils.cache import patch_vary_headers
 from django.utils.six.moves.urllib.parse import urlparse
 
 from .conf import conf
@@ -124,6 +125,7 @@ class CorsMiddleware(MiddlewareMixin):
                 response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
             else:
                 response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
+                patch_vary_headers(response, ['Origin'])
 
             if len(conf.CORS_EXPOSE_HEADERS):
                 response[ACCESS_CONTROL_EXPOSE_HEADERS] = ', '.join(conf.CORS_EXPOSE_HEADERS)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -255,6 +255,21 @@ class TestCorsMiddlewareProcessResponse(TestCase):
         response = self.client.get('/test-view/', HTTP_ORIGIN='http://foobar.it')
         assert response.status_code == 200
         assert response[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://foobar.it'
+        assert response['Vary'] == 'Origin'
+
+    @override_settings(
+        CORS_ALLOW_CREDENTIALS=True,
+        CORS_ORIGIN_ALLOW_ALL=True,
+    )
+    def test_middleware_integration_options(self):
+        response = self.client.options(
+            '/test-view/',
+            HTTP_ORIGIN='http://foobar.it',
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+        )
+        assert response.status_code == 200
+        assert response[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://foobar.it'
+        assert response['Vary'] == 'Origin'
 
     @override_settings(
         CORS_ALLOW_CREDENTIALS=True,


### PR DESCRIPTION
Only when not allowing all origins, as per the [Mozilla CORS docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS). Fixes #63.