### PR TITLE
Conditionally process a response if other middleware is short circuiting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,15 @@ History
 Pending
 -------
 
-* New release notes go here.
+* Conditionally process a response if other middleware is short circuiting. In a
+  scenario when a middleware that returns a response is run before the
+  ``CorsMiddleware`` and the project uses ``MIDDLEWARE_CLASSES``, the response
+  will be processed and CORS headers will be added if applicable . When
+  ``MIDDLEWARE`` is used, the response will not be processed and CORS response
+  headers won't be added to the response. This does not change existing behavior
+  but does fix an ``AttributeError`` introduced in 1.3.0 in the short circuit
+  scenario with ``MIDDLEWARE_CLASSES`` used.
+
 
 1.3.0 (2016-11-06)
 ------------------

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ from django.test.utils import modify_settings
 from corsheaders.signals import check_request_enabled
 
 
-def append_middleware(path):
+def add_middleware(action, path):
     if django.VERSION[:2] >= (1, 10):
         middleware_setting = 'MIDDLEWARE'
     else:
@@ -14,9 +14,17 @@ def append_middleware(path):
 
     return modify_settings(**{
         middleware_setting: {
-            'append': path
+            action: path,
         }
     })
+
+
+def append_middleware(path):
+    return add_middleware('append', path)
+
+
+def prepend_middleware(path):
+    return add_middleware('prepend', path)
 
 
 @contextmanager


### PR DESCRIPTION
In a scenario when a middleware that returns a response is run before
the ``CorsMiddleware`` and the project uses ``MIDDLEWARE_CLASSES``, the
response will be processed and CORS headers will be added if applicable.
When ``MIDDLEWARE`` is used, the response will not be processed and CORS
response headers won't be added to the response. This does not change
existing behavior but does fix an ``AttributeError`` introduced in 1.3.0
in the short circuit scenario with ``MIDDLEWARE_CLASSES`` used.