### PR TITLE
Tests - cover previously uncovered line

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -58,8 +58,9 @@ class CorsMiddleware(MiddlewareMixin):
         if request.is_secure() and origin and 'ORIGINAL_HTTP_REFERER' not in request.META:
 
             url = urlparse(origin)
+            print(self.origin_not_found_in_white_lists(origin, url))
             if not conf.CORS_ORIGIN_ALLOW_ALL and self.origin_not_found_in_white_lists(origin, url):
-                return  # pragma: no cover
+                return
 
             try:
                 http_referer = request.META['HTTP_REFERER']

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -315,7 +315,7 @@ class CorsMiddlewareTests(TestCase):
 
 @override_settings(
     CORS_REPLACE_HTTPS_REFERER=True,
-    CORS_ORIGIN_REGEX_WHITELIST=r'.*example.*',
+    CORS_ORIGIN_REGEX_WHITELIST=(r'.*example.*',),
 )
 class RefererReplacementCorsMiddlewareTests(TestCase):
 
@@ -378,6 +378,18 @@ class RefererReplacementCorsMiddlewareTests(TestCase):
         resp = self.client.get(
             '/',
             HTTP_FAKE_SECURE='true',
+            HTTP_ORIGIN='https://example.org',
+            HTTP_REFERER='https://example.org/foo',
+        )
+        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.org/foo'
+        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+
+    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=())
+    def test_get_does_not_replace_referer_when_not_valid_request(self):
+        resp = self.client.get(
+            '/',
+            HTTP_FAKE_SECURE='true',
+            HTTP_HOST='example.com',
             HTTP_ORIGIN='https://example.org',
             HTTP_REFERER='https://example.org/foo',
         )


### PR DESCRIPTION
Add test coverage to the only non-conditional line that's not covered. Fixes #152.

Also fixes a problem with the test case that was using a bad regex.