### PR TITLE
Use compat module

### DIFF
--- a/corsheaders/compat.py
+++ b/corsheaders/compat.py
@@ -1,0 +1,6 @@
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # pragma: no cover
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object  # pragma: no cover

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -5,15 +5,9 @@ from django.apps import apps
 from django.utils.cache import patch_vary_headers
 from django.utils.six.moves.urllib.parse import urlparse
 
+from .compat import MiddlewareMixin
 from .conf import conf
 from .signals import check_request_enabled
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:  # pragma: no cover
-    # Not required for Django <= 1.9, see:
-    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
-    MiddlewareMixin = object  # pragma: no cover
 
 ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
 ACCESS_CONTROL_EXPOSE_HEADERS = 'Access-Control-Expose-Headers'

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from corsheaders.compat import MiddlewareMixin
 from corsheaders.middleware import (
     ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
     ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE,
@@ -14,11 +15,6 @@ from .utils import (
     prepend_middleware,
     temporary_check_request_hander,
 )
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:  # pragma: no cover
-    MiddlewareMixin = object  # pragma: no cover
 
 
 class ShortCircuitMiddleware(MiddlewareMixin):


### PR DESCRIPTION
Centralize on a single version of the pre/post Django 1.10 compat imports so that it's easier to change.