### PR TITLE
Fix when the model defined by CORS_MODEL is checked

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 Pending
 -------
 
-* New release notes go here.
+* Make sure that access-control-allow-credentials is in the response if client asks for it
 
 1.3.1 (2016-11-09)
 ------------------

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -115,6 +115,9 @@ class CorsMiddleware(MiddlewareMixin):
             if model.objects.filter(cors=url.netloc).exists():
                 response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
 
+        if conf.CORS_ALLOW_CREDENTIALS:
+            response[ACCESS_CONTROL_ALLOW_CREDENTIALS] = 'true'
+
         if (
             not conf.CORS_ORIGIN_ALLOW_ALL and
             not self.origin_found_in_white_lists(origin, url) and
@@ -130,9 +133,6 @@ class CorsMiddleware(MiddlewareMixin):
 
         if len(conf.CORS_EXPOSE_HEADERS):
             response[ACCESS_CONTROL_EXPOSE_HEADERS] = ', '.join(conf.CORS_EXPOSE_HEADERS)
-
-        if conf.CORS_ALLOW_CREDENTIALS:
-            response[ACCESS_CONTROL_ALLOW_CREDENTIALS] = 'true'
 
         if request.method == 'OPTIONS':
             response[ACCESS_CONTROL_ALLOW_HEADERS] = ', '.join(conf.CORS_ALLOW_HEADERS)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -125,6 +125,13 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
         assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
 
+    @override_settings(CORS_MODEL='corsheaders.CorsModel', CORS_ALLOW_CREDENTIALS=True)
+    def test_get_when_custom_model_enabled_and_allow_credentials(self):
+        CorsModel.objects.create(cors='example.com')
+        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
+        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == 'true'
+
     def test_options(self):
         resp = self.client.options(
             '/',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -124,6 +124,7 @@ class CorsMiddlewareTests(TestCase):
         CorsModel.objects.create(cors='example.com')
         resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
         assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
+        assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
 
     @override_settings(CORS_MODEL='corsheaders.CorsModel', CORS_ALLOW_CREDENTIALS=True)
     def test_get_when_custom_model_enabled_and_allow_credentials(self):


### PR DESCRIPTION
There are cases in the current code where it does not reach the assignment because the function already sends a response before it gets assigned.

```
if conf.CORS_MODEL is not None:
    model = apps.get_model(*conf.CORS_MODEL.split('.'))
    if model.objects.filter(cors=url.netloc).exists():
        response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin

if (
    not conf.CORS_ORIGIN_ALLOW_ALL and
    not self.origin_found_in_white_lists(origin, url) and
    not self.check_signal(request)
):
    return response
```

In our API server, we want to maintain a CORS whitelist via CorsModel but the API client
has `xhr.withCredentials = true` when making the request. With the current code we get this error:

```
XMLHttpRequest cannot load https://api.ourdomain.com/v1/something/. Credentials
flag is 'true', but the 'Access-Control-Allow-Credentials' header is ''. It must be 'true'
to allow credentials. Origin 'http://domainnameofapiclient.com' is therefore not allowed access.

```