### PR TITLE
Test against Django 1.11

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,5 @@ multilint
 pytest
 pytest-cov
 pytest-django
+pytz
 Pygments

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ Pygments==2.1.3
 pytest-cov==2.4.0
 pytest-django==3.1.2
 pytest==3.0.5
+pytz==2016.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,35}-django{18,19,110}
+    py{27,35}-django{18,19,110,111}
 
 [testenv]
 setenv =
@@ -12,7 +12,16 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11a1,<2.0
 commands = ./runtests.py {posargs}
+
+# Tests currently fail under Django 1.11:
+# https://github.com/ottoyiu/django-cors-headers/issues/197
+[testenv:py27-django111]
+ignore_outcome = True
+
+[testenv:py35-django111]
+ignore_outcome = True
 
 [testenv:py27-codestyle]
 commands = multilint


### PR DESCRIPTION
**1) Remove --no-deps from Tox pip install**
Since as of Django 1.11, installing Django is expected to pull in dependencies (pytz). Specifying pytz in django-cors-headers' setup.py would defeat the point of inherited unpinned install_requires packages, and adding to the test requirements.txt doesn't make sense either, given pytz is not just required for tests. As such, whilst the `--no-deps` parameter made sense (to avoid accidental unpinned test dependencies), it's best to just not use it.

**2) Test against Django 1.11 but allow failures**
Since tests are currently failing (see #197). The `>=1.11a1,<2.0` specifier will avoid having to adjust the version as the Django 1.11 pre-release cycle continues.

A later PR can:
* fix the failure test under Django 1.11 (#197)
* remove the annotation that allows failure
* adjust readme/docs and setup.py classifiers to include Django 1.11