### PR TITLE
ADDED: origin_found_in_cors_model_lists to check whether the domain exists in table or not 

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -121,6 +121,7 @@ class CorsMiddleware(MiddlewareMixin):
         if (
             not conf.CORS_ORIGIN_ALLOW_ALL and
             not self.origin_found_in_white_lists(origin, url) and
+            not self.origin_found_in_cors_model_lists(origin, url) and
             not self.check_signal(request)
         ):
             return response
@@ -148,6 +149,17 @@ class CorsMiddleware(MiddlewareMixin):
             (origin == 'null' and origin in conf.CORS_ORIGIN_WHITELIST) or
             self.regex_domain_match(origin)
         )
+    
+    def origin_found_in_cors_model_lists(self, origin, url):
+        if conf.CORS_MODEL is not None:
+            model = apps.get_model(*conf.CORS_MODEL.split('.'))
+            return (
+                model.objects.filter(cors=url.netloc).exists()
+            )
+        else:
+            return (
+                False
+            )
 
     def regex_domain_match(self, origin):
         for domain_pattern in conf.CORS_ORIGIN_REGEX_WHITELIST:

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -110,6 +110,7 @@ class CorsMiddleware(MiddlewareMixin):
         # todo: check hostname from db instead
         url = urlparse(origin)
 
+        model = None
         if conf.CORS_MODEL is not None:
             model = apps.get_model(*conf.CORS_MODEL.split('.'))
             if model.objects.filter(cors=url.netloc).exists():
@@ -151,15 +152,8 @@ class CorsMiddleware(MiddlewareMixin):
         )
     
     def origin_found_in_cors_model_lists(self, origin, url):
-        if conf.CORS_MODEL is not None:
-            model = apps.get_model(*conf.CORS_MODEL.split('.'))
-            return (
-                model.objects.filter(cors=url.netloc).exists()
-            )
-        else:
-            return (
-                False
-            )
+        if model:
+            return model.objects.filter(cors=url.netloc).exists()
 
     def regex_domain_match(self, origin):
         for domain_pattern in conf.CORS_ORIGIN_REGEX_WHITELIST:

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -40,6 +40,8 @@ class CorsPostCsrfMiddleware(MiddlewareMixin):
 
 class CorsMiddleware(MiddlewareMixin):
 
+    model = None
+
     def _https_referer_replace(self, request):
         """
         When https is enabled, django CSRF checking includes referer checking
@@ -122,7 +124,7 @@ class CorsMiddleware(MiddlewareMixin):
         if (
             not conf.CORS_ORIGIN_ALLOW_ALL and
             not self.origin_found_in_white_lists(origin, url) and
-            not self.origin_found_in_cors_model_lists(origin, url) and
+            not self.origin_found_in_cors_model_lists(origin, url, model) and
             not self.check_signal(request)
         ):
             return response
@@ -150,8 +152,8 @@ class CorsMiddleware(MiddlewareMixin):
             (origin == 'null' and origin in conf.CORS_ORIGIN_WHITELIST) or
             self.regex_domain_match(origin)
         )
-    
-    def origin_found_in_cors_model_lists(self, origin, url):
+
+    def origin_found_in_cors_model_lists(self, origin, url, model):
         if model:
             return model.objects.filter(cors=url.netloc).exists()
 


### PR DESCRIPTION
I want to contribute to django-cors-headers library with the following changes:

1) need to add origin_found_in_cors_model_lists which will check in modal if the data exists in model and checks for domain name 

 this is resolve the issue :
 Using CORS_MODEL with custom headers #191

need to add origin_found_in_cors_model_lists which will check in modal if the data exists in model and checks for domain name and that helps to adding the headers in
        if (
            not conf.CORS_ORIGIN_ALLOW_ALL and
            not self.origin_found_in_white_lists(origin, url) and
            not self.check_signal(request)
        ):
            **return** response

since here we are not checking for model i have added the above function for checking it 
```
if this condition fails then it added the below headers if the 
        if request.method == 'OPTIONS':
            response[ACCESS_CONTROL_ALLOW_HEADERS] = ', '.join(conf.CORS_ALLOW_HEADERS)
            response[ACCESS_CONTROL_ALLOW_METHODS] = ', '.join(conf.CORS_ALLOW_METHODS)
            if conf.CORS_PREFLIGHT_MAX_AGE:
                response[ACCESS_CONTROL_MAX_AGE] = conf.CORS_PREFLIGHT_MAX_AGE
```
thanks
Kantanand Us
