### PR TITLE
file:// should also be treated as null

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -141,7 +141,7 @@ class CorsMiddleware(MiddlewareMixin):
     def origin_found_in_white_lists(self, origin, url):
         return (
             url.netloc in conf.CORS_ORIGIN_WHITELIST or
-            (origin == 'null' and origin in conf.CORS_ORIGIN_WHITELIST) or
+            (origin in ('null', 'file://') and origin in conf.CORS_ORIGIN_WHITELIST) or
             self.regex_domain_match(origin)
         )
 


### PR DESCRIPTION
when testing cordova ios, webworker sends origin ``file://`` so I guess the same way ``null`` is treated, ``file://`` should be too