### PR TITLE
Always Vary by Origin to prevent cache contamination in downstream ca…

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -97,6 +97,9 @@ class CorsMiddleware(MiddlewareMixin):
         Add the respective CORS headers
         """
         origin = request.META.get('HTTP_ORIGIN')
+        # Always vary by Origin, hereby preventing downstream caches from
+        # mixing objects for whitelisted and not-whitelisted origins.
+        patch_vary_headers(response, ['Origin'])
         if not origin:
             return response
 
@@ -125,7 +128,6 @@ class CorsMiddleware(MiddlewareMixin):
             response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
         else:
             response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
-            patch_vary_headers(response, ['Origin'])
 
         if len(conf.CORS_EXPOSE_HEADERS):
             response[ACCESS_CONTROL_EXPOSE_HEADERS] = ', '.join(conf.CORS_EXPOSE_HEADERS)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -25,6 +25,10 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get('/')
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
+    def test_get_origin_vary_by_default(self):
+        resp = self.client.get('/')
+        assert resp['Vary'] == 'Origin'
+
     @override_settings(CORS_ORIGIN_WHITELIST=['example.com'])
     def test_get_not_in_whitelist(self):
         resp = self.client.get('/', HTTP_ORIGIN='http://example.org')


### PR DESCRIPTION
…ches relying on the Vary header.

Hey, 

After going through the README and looking at the source, I couldn't come up with a different solution then writing a pull request.

I had made the assumption that the `Vary` header would always be patched, regardless of the fact if the requesting Origin was whitelisted (either by regex, the whitelist or by any other means).

After deploying to production, I found it wasn't the case. Our downstream cache was sometimes sending responses where the `Access-Control-Allow-Origin` was not present. After some debugging I found out it was serving objects that were requested with a none-whitelisted `Origin` request header. 

An alternative to this solution would have been to force the downstream cache to always hash based on the `Origin` request header, but I like this approach better because it scales much better by providing flexibility. But in that case the Vary header must be set for origins.

Perhaps I'm completely trying to tackle this problem from the wrong angle, and any discussion would be greatly appreciated.

Secondly, when going through the unit tests, I found out that there's some 'undocumented' behaviour. Usually when setting `CORS_ORIGIN_ALLOW_ALL=True` the `*` will be set  as `Access-Control-Allow-Origin' header. However when also setting `CORS_ALLOW_CREDENTIALS=True`, the full origin is returned instead of `*`. 

