### PR TITLE
Fix all warnings in tests

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,9 +15,14 @@ INSTALLED_APPS = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'TEST_NAME': ':memory:',
     },
 }
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    },
+]
 
 ROOT_URLCONF = 'tests.urls'
 


### PR DESCRIPTION
Just a couple settings warnings from Django.

```
tests/test_checks.py::ChecksTests::test_checks_are_bound
  /Users/adam/Documents/Projects/django-cors-headers/.tox/py27-django18/lib/python2.7/site-packages/django/db/utils.py:239: RemovedInDjango19Warning: In Django 1.9 the TEST_NAME connection setting will be moved to a NAME entry in the TEST setting
    self.prepare_test_settings(alias)
```

and 

```
tests/test_middleware.py::CorsMiddlewareTests::test_options_adds_origin_when_domain_found_in_origin_regex_whitelist
  /Users/adam/Documents/Projects/django-cors-headers/.tox/py36-django19/lib/python3.6/site-packages/django/template/utils.py:37: RemovedInDjango110Warning: You haven't defined a TEMPLATES setting. You must do so before upgrading to Django 1.10. Otherwise Django will be unable to load templates.
    "unable to load templates.", RemovedInDjango110Warning)
```