### PR TITLE
Add Content-Length to preflight responses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 Pending
 -------
 
-* New release notes go here.
+* Add ``Content-Length`` header to CORS preflight requests. This fixes issues
+  with some HTTP proxies/servers (e.g. AWS Elastic Beanstalk)
 
 2.2.0 (2018-02-28)
 ------------------

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -84,7 +84,9 @@ class CorsMiddleware(MiddlewareMixin):
                 request.method == 'OPTIONS' and
                 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' in request.META
             ):
-                return http.HttpResponse()
+                response = http.HttpResponse()
+                response['Content-Length'] = '0'
+                return response
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
         """

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -227,6 +227,7 @@ class CorsMiddlewareTests(TestCase):
         )
         assert resp.status_code == 200
         assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
+        assert resp['Content-Length'] == '0'
 
     def test_signal_handler_that_returns_false(self):
         def handler(*args, **kwargs):


### PR DESCRIPTION
Hi,
I'm currently developing a Django App which uses Rest Framework with AuthToken and (obviously) CORS-Headers.
My app is deployed at AWS Elastic Beanstalk (currently We use dev-server) and I stumbled upon the following issue:
AWS EB responds with `502 BAD_GATEWAY` error with a client tries to make a preflight request.

After some debugging, it seems that the issue is caused by the lack of `Content-Length` header.
That issue can be solved in multiple ways e.g. by setting this header in the Nginx, Apache or any other web server.
I'm not sure if that's mergeable, but it may help other people with this problem.
Could you review this @ottoyiu ?
Thanks in advance, your library saved me a lot of time!
