### PR TITLE
Compare path_info instead of path to the URL regex

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,9 @@ History
 Pending
 -------
 
-* New release notes go here.
+* Match ``CORS_URLS_REGEX`` to ``request.path_info`` instead of
+  ``request.path``, so the patterns can work without knowing the site's path
+  prefix at configuration time.
 
 2.2.0 (2018-02-28)
 ------------------

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -160,7 +160,7 @@ class CorsMiddleware(MiddlewareMixin):
 
     def is_enabled(self, request):
         return (
-            bool(re.match(conf.CORS_URLS_REGEX, request.path)) or
+            bool(re.match(conf.CORS_URLS_REGEX, request.path_info)) or
             self.check_signal(request)
         )
 


### PR DESCRIPTION
This makes the configuration much more simpler when a site is set to under a non-empty `WSGIScriptAlias`.

Say I have a site deployed under `/sub`. My API would then be served in `/sub/api`, and with the previous implementation, my `CORS_URLS_REGEX` would need to be set to

```python
CORS_URLS_REGEX = r'^/sub/api.*$'
```

to work in production, but this won’t work locally when I run under `http://localhost:8000`, and my API served in `http://localhost:8000/api`.

Using `path_info` instead of `path` would allow me to always specify

```python
CORS_URLS_REGEX = r'^/api.*$'
```

and match correctly, no matter whether I have `WSGIScriptAlias` set, and no matter what value I set it to.

See: https://docs.djangoproject.com/en/2.0/ref/request-response/#django.http.HttpRequest.path_info