### PR TITLE
Added whitelist support for Access-Control-Allow-Credentials header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,12 +212,12 @@ If ``True``, cookies will be allowed to be included in cross-site HTTP
 requests. Defaults to ``False``.
 
 ``CORS_ORIGIN_CREDENTIALS_ALLOW_ALL``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If ``True``, the whitelist will not be usedand cookies from all origins
 will be accepted. Defaults to ``True``.
 
 ``CORS_ORIGIN_CREDENTIALS_WHITELIST``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list of origin hostnames that are authorized to make cross-site HTTP
 requests with cookies.
@@ -225,7 +225,7 @@ For more information, see ``CORS_ORIGIN_CREDENTIALS_WHITELIST``.
 Defaults to ``[]``.
 
 ``CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list of regexes that match origin regex list of origin hostnames that are
 authorized to make cross-site HTTP requests with cookies.

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,27 @@ actually accepts. Read more about it in the `HTML 5 Rocks CORS tutorial
 If ``True``, cookies will be allowed to be included in cross-site HTTP
 requests. Defaults to ``False``.
 
+``CORS_ORIGIN_CREDENTIALS_ALLOW_ALL``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+If ``True``, the whitelist will not be usedand cookies from all origins
+will be accepted. Defaults to ``True``.
+
+``CORS_ORIGIN_CREDENTIALS_WHITELIST``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A list of origin hostnames that are authorized to make cross-site HTTP
+requests with cookies.
+For more information, see ``CORS_ORIGIN_CREDENTIALS_WHITELIST``.
+Defaults to ``[]``.
+
+``CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A list of regexes that match origin regex list of origin hostnames that are
+authorized to make cross-site HTTP requests with cookies.
+For more information, see ``CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST``.
+Defaults to ``[]``.
+
 ``CORS_MODEL``
 ~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ to allow all hosts.
 
 ``CORS_ORIGIN_ALLOW_ALL``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If ``True``, the whitelist will not be used and all origins will be accepted.
 Defaults to ``False``.
 
@@ -213,6 +214,7 @@ requests. Defaults to ``False``.
 
 ``CORS_ORIGIN_CREDENTIALS_ALLOW_ALL``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If ``True``, the whitelist will not be usedand cookies from all origins
 will be accepted. Defaults to ``True``.
 

--- a/corsheaders/__init__.py
+++ b/corsheaders/__init__.py
@@ -1,3 +1,3 @@
-from .checks import check_settings  # noqa: F401
+from .checks import *  # noqa: F401,F403
 
 __version__ = '2.3.0'

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -12,121 +12,94 @@ from .conf import conf
 re_type = type(re.compile(''))
 
 
+check_list = [
+    (
+        lambda: not is_sequence(conf.CORS_ALLOW_HEADERS, six.string_types),
+        'CORS_ALLOW_HEADERS should be a sequence of strings.',
+        'corsheaders.E001',
+    ),
+    (
+        lambda: not is_sequence(conf.CORS_ALLOW_METHODS, six.string_types),
+        'CORS_ALLOW_METHODS should be a sequence of strings.',
+        'corsheaders.E002',
+    ),
+    (
+        lambda: not isinstance(conf.CORS_ALLOW_CREDENTIALS, bool),
+        'CORS_ALLOW_CREDENTIALS should be a bool.',
+        'corsheaders.E003',
+    ),
+    (
+        lambda: not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0,
+        'CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.',
+        'corsheaders.E004',
+    ),
+    (
+        lambda: not isinstance(conf.CORS_ORIGIN_ALLOW_ALL, bool),
+        'CORS_ORIGIN_ALLOW_ALL should be a bool.',
+        'corsheaders.E005',
+    ),
+    (
+        lambda: not is_sequence(conf.CORS_ORIGIN_WHITELIST, six.string_types),
+        'CORS_ORIGIN_WHITELIST should be a sequence of strings.',
+        'corsheaders.E006',
+    ),
+    (
+        lambda: not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)),
+        'CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.',
+        'corsheaders.E007',
+    ),
+    (
+        lambda: not is_sequence(conf.CORS_EXPOSE_HEADERS, six.string_types),
+        'CORS_EXPOSE_HEADERS should be a sequence.',
+        'corsheaders.E008',
+    ),
+    (
+        lambda: not isinstance(conf.CORS_URLS_REGEX, six.string_types + (re_type,)),
+        'CORS_URLS_REGEX should be a string or regex.',
+        'corsheaders.E009',
+    ),
+    (
+        lambda: conf.CORS_MODEL is not None and not isinstance(conf.CORS_MODEL, six.string_types),
+        'CORS_MODEL should be a string or None.',
+        'corsheaders.E010',
+    ),
+    (
+        lambda: not isinstance(conf.CORS_REPLACE_HTTPS_REFERER, bool),
+        'CORS_REPLACE_HTTPS_REFERER should be a bool.',
+        'corsheaders.E011',
+    ),
+    (
+        lambda: not isinstance(conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool),
+        'CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.',
+        'corsheaders.E012',
+    ),
+    (
+        lambda: not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types),
+        'CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.',
+        'corsheaders.E013',
+    ),
+    (
+        lambda: not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)),
+        'CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.',
+        'corsheaders.E014',
+    ),
+]
+
+
+def check_cors_allow_headers():
+    return
+
+
 @checks.register
 def check_settings(app_configs, **kwargs):
     errors = []
-
-    if not is_sequence(conf.CORS_ALLOW_HEADERS, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ALLOW_HEADERS should be a sequence of strings.",
-                id="corsheaders.E001"
-            )
-        )
-
-    if not is_sequence(conf.CORS_ALLOW_METHODS, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ALLOW_METHODS should be a sequence of strings.",
-                id="corsheaders.E002"
-            )
-        )
-
-    if not isinstance(conf.CORS_ALLOW_CREDENTIALS, bool):
-        errors.append(
-            checks.Error(
-                "CORS_ALLOW_CREDENTIALS should be a bool.",
-                id="corsheaders.E003"
-            )
-        )
-
-    if not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0:
-        errors.append(
-            checks.Error(
-                "CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.",
-                id="corsheaders.E004"
-            )
-        )
-
-    if not isinstance(conf.CORS_ORIGIN_ALLOW_ALL, bool):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_ALLOW_ALL should be a bool.",
-                id="corsheaders.E005"
-            )
-        )
-
-    if not is_sequence(conf.CORS_ORIGIN_WHITELIST, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
-                id="corsheaders.E006"
-            )
-        )
-
-    if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
-                id="corsheaders.E007"
-            )
-        )
-
-    if not is_sequence(conf.CORS_EXPOSE_HEADERS, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_EXPOSE_HEADERS should be a sequence.",
-                id="corsheaders.E008"
-            )
-        )
-
-    if not isinstance(conf.CORS_URLS_REGEX, six.string_types + (re_type,)):
-        errors.append(
-            checks.Error(
-                "CORS_URLS_REGEX should be a string or regex.",
-                id="corsheaders.E009"
-            )
-        )
-
-    if conf.CORS_MODEL is not None and not isinstance(conf.CORS_MODEL, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_MODEL should be a string or None.",
-                id="corsheaders.E010"
-            )
-        )
-
-    if not isinstance(conf.CORS_REPLACE_HTTPS_REFERER, bool):
-        errors.append(
-            checks.Error(
-                "CORS_REPLACE_HTTPS_REFERER should be a bool.",
-                id="corsheaders.E011"
-            )
-        )
-
-    if not isinstance(conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.",
-                id="corsheaders.E012"
-            )
-        )
-
-    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.",
-                id="corsheaders.E013"
-            )
-        )
-
-    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
-                id="corsheaders.E014"
-            )
-        )
+    for check in check_list:
+        check_func, error_message, check_id = check
+        if check_func():
+            errors.append(checks.Error(
+                error_message,
+                id=check_id
+            ))
 
     return errors
 

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -104,6 +104,30 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
+    if not isinstance(conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.",
+                id="corsheaders.E012"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.",
+                id="corsheaders.E013"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
+                id="corsheaders.E014"
+            )
+        )
+
     return errors
 
 

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -12,123 +12,144 @@ from .conf import conf
 re_type = type(re.compile(''))
 
 
-@checks.register
-def check_settings(app_configs, **kwargs):
-    errors = []
+@checks.register('corsheaders', 'settings')
+def check_cors_allow_headers(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ALLOW_HEADERS should be a sequence of strings.",
+        id="corsheaders.E001"
+    )] if not is_sequence(
+        conf.CORS_ALLOW_HEADERS, six.string_types
+    ) else []
 
-    if not is_sequence(conf.CORS_ALLOW_HEADERS, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ALLOW_HEADERS should be a sequence of strings.",
-                id="corsheaders.E001"
-            )
-        )
 
-    if not is_sequence(conf.CORS_ALLOW_METHODS, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ALLOW_METHODS should be a sequence of strings.",
-                id="corsheaders.E002"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_allow_methods(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ALLOW_METHODS should be a sequence of strings.",
+        id="corsheaders.E002"
+    )] if not is_sequence(
+        conf.CORS_ALLOW_METHODS, six.string_types
+    ) else []
 
-    if not isinstance(conf.CORS_ALLOW_CREDENTIALS, bool):
-        errors.append(
-            checks.Error(
-                "CORS_ALLOW_CREDENTIALS should be a bool.",
-                id="corsheaders.E003"
-            )
-        )
 
-    if not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0:
-        errors.append(
-            checks.Error(
-                "CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.",
-                id="corsheaders.E004"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_allow_credentials(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ALLOW_CREDENTIALS should be a bool.",
+        id="corsheaders.E003"
+    )] if not isinstance(
+        conf.CORS_ALLOW_CREDENTIALS, bool
+    ) else []
 
-    if not isinstance(conf.CORS_ORIGIN_ALLOW_ALL, bool):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_ALLOW_ALL should be a bool.",
-                id="corsheaders.E005"
-            )
-        )
 
-    if not is_sequence(conf.CORS_ORIGIN_WHITELIST, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
-                id="corsheaders.E006"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_preflight_max_age(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.",
+        id="corsheaders.E004"
+    )] if (
+        not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0
+    ) else []
 
-    if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
-                id="corsheaders.E007"
-            )
-        )
 
-    if not is_sequence(conf.CORS_EXPOSE_HEADERS, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_EXPOSE_HEADERS should be a sequence.",
-                id="corsheaders.E008"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_origin_allow_all(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ORIGIN_ALLOW_ALL should be a bool.",
+        id="corsheaders.E005"
+    )] if not isinstance(
+        conf.CORS_ORIGIN_ALLOW_ALL, bool
+    ) else []
 
-    if not isinstance(conf.CORS_URLS_REGEX, six.string_types + (re_type,)):
-        errors.append(
-            checks.Error(
-                "CORS_URLS_REGEX should be a string or regex.",
-                id="corsheaders.E009"
-            )
-        )
 
-    if conf.CORS_MODEL is not None and not isinstance(conf.CORS_MODEL, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_MODEL should be a string or None.",
-                id="corsheaders.E010"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_origin_whitelist(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
+        id="corsheaders.E006"
+    )] if not is_sequence(
+        conf.CORS_ORIGIN_WHITELIST, six.string_types
+    ) else []
 
-    if not isinstance(conf.CORS_REPLACE_HTTPS_REFERER, bool):
-        errors.append(
-            checks.Error(
-                "CORS_REPLACE_HTTPS_REFERER should be a bool.",
-                id="corsheaders.E011"
-            )
-        )
 
-    if not isinstance(conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.",
-                id="corsheaders.E012"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_origin_regex_whitelist(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
+        id="corsheaders.E007"
+    )] if not is_sequence(
+        conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)
+    ) else []
 
-    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.",
-                id="corsheaders.E013"
-            )
-        )
 
-    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)):
-        errors.append(
-            checks.Error(
-                "CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
-                id="corsheaders.E014"
-            )
-        )
+@checks.register('corsheaders', 'settings')
+def check_cors_expose_headers(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_EXPOSE_HEADERS should be a sequence.",
+        id="corsheaders.E008"
+    )] if not is_sequence(
+        conf.CORS_EXPOSE_HEADERS, six.string_types
+    ) else []
 
-    return errors
+
+@checks.register('corsheaders', 'settings')
+def check_cors_urls_regex(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_URLS_REGEX should be a string or regex.",
+        id="corsheaders.E009"
+    )] if not isinstance(
+        conf.CORS_URLS_REGEX, six.string_types + (re_type,)
+    ) else []
+
+
+@checks.register('corsheaders', 'settings')
+def check_cors_model(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_MODEL should be a string or None.",
+        id="corsheaders.E010"
+    )] if (
+        conf.CORS_MODEL is not None and not isinstance(conf.CORS_MODEL, six.string_types)
+    ) else []
+
+
+@checks.register('corsheaders', 'settings')
+def check_cors_replace_https_referer(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_REPLACE_HTTPS_REFERER should be a bool.",
+        id="corsheaders.E011"
+    )] if not isinstance(
+        conf.CORS_REPLACE_HTTPS_REFERER, bool
+    ) else []
+
+
+@checks.register('corsheaders', 'settings')
+def check_cors_origin_credentials_allow_all(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.",
+        id="corsheaders.E012"
+    )] if not isinstance(
+        conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool
+    ) else []
+
+
+@checks.register('corsheaders', 'settings')
+def check_cors_origin_credentials_whitelist(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.",
+        id="corsheaders.E013"
+    )] if not is_sequence(
+        conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types
+    ) else []
+
+
+@checks.register('corsheaders', 'settings')
+def check_cors_origin_credentials_regex_whitelist(app_configs, **kwargs):
+    return [checks.Error(
+        "CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
+        id="corsheaders.E014"
+    )] if not is_sequence(
+        conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)
+    ) else []
 
 
 def is_sequence(thing, types):

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -12,94 +12,121 @@ from .conf import conf
 re_type = type(re.compile(''))
 
 
-check_list = [
-    (
-        lambda: not is_sequence(conf.CORS_ALLOW_HEADERS, six.string_types),
-        'CORS_ALLOW_HEADERS should be a sequence of strings.',
-        'corsheaders.E001',
-    ),
-    (
-        lambda: not is_sequence(conf.CORS_ALLOW_METHODS, six.string_types),
-        'CORS_ALLOW_METHODS should be a sequence of strings.',
-        'corsheaders.E002',
-    ),
-    (
-        lambda: not isinstance(conf.CORS_ALLOW_CREDENTIALS, bool),
-        'CORS_ALLOW_CREDENTIALS should be a bool.',
-        'corsheaders.E003',
-    ),
-    (
-        lambda: not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0,
-        'CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.',
-        'corsheaders.E004',
-    ),
-    (
-        lambda: not isinstance(conf.CORS_ORIGIN_ALLOW_ALL, bool),
-        'CORS_ORIGIN_ALLOW_ALL should be a bool.',
-        'corsheaders.E005',
-    ),
-    (
-        lambda: not is_sequence(conf.CORS_ORIGIN_WHITELIST, six.string_types),
-        'CORS_ORIGIN_WHITELIST should be a sequence of strings.',
-        'corsheaders.E006',
-    ),
-    (
-        lambda: not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)),
-        'CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.',
-        'corsheaders.E007',
-    ),
-    (
-        lambda: not is_sequence(conf.CORS_EXPOSE_HEADERS, six.string_types),
-        'CORS_EXPOSE_HEADERS should be a sequence.',
-        'corsheaders.E008',
-    ),
-    (
-        lambda: not isinstance(conf.CORS_URLS_REGEX, six.string_types + (re_type,)),
-        'CORS_URLS_REGEX should be a string or regex.',
-        'corsheaders.E009',
-    ),
-    (
-        lambda: conf.CORS_MODEL is not None and not isinstance(conf.CORS_MODEL, six.string_types),
-        'CORS_MODEL should be a string or None.',
-        'corsheaders.E010',
-    ),
-    (
-        lambda: not isinstance(conf.CORS_REPLACE_HTTPS_REFERER, bool),
-        'CORS_REPLACE_HTTPS_REFERER should be a bool.',
-        'corsheaders.E011',
-    ),
-    (
-        lambda: not isinstance(conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool),
-        'CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.',
-        'corsheaders.E012',
-    ),
-    (
-        lambda: not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types),
-        'CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.',
-        'corsheaders.E013',
-    ),
-    (
-        lambda: not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)),
-        'CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.',
-        'corsheaders.E014',
-    ),
-]
-
-
-def check_cors_allow_headers():
-    return
-
-
 @checks.register
 def check_settings(app_configs, **kwargs):
     errors = []
-    for check in check_list:
-        check_func, error_message, check_id = check
-        if check_func():
-            errors.append(checks.Error(
-                error_message,
-                id=check_id
-            ))
+
+    if not is_sequence(conf.CORS_ALLOW_HEADERS, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_ALLOW_HEADERS should be a sequence of strings.",
+                id="corsheaders.E001"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ALLOW_METHODS, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_ALLOW_METHODS should be a sequence of strings.",
+                id="corsheaders.E002"
+            )
+        )
+
+    if not isinstance(conf.CORS_ALLOW_CREDENTIALS, bool):
+        errors.append(
+            checks.Error(
+                "CORS_ALLOW_CREDENTIALS should be a bool.",
+                id="corsheaders.E003"
+            )
+        )
+
+    if not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0:
+        errors.append(
+            checks.Error(
+                "CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.",
+                id="corsheaders.E004"
+            )
+        )
+
+    if not isinstance(conf.CORS_ORIGIN_ALLOW_ALL, bool):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_ALLOW_ALL should be a bool.",
+                id="corsheaders.E005"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ORIGIN_WHITELIST, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
+                id="corsheaders.E006"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
+                id="corsheaders.E007"
+            )
+        )
+
+    if not is_sequence(conf.CORS_EXPOSE_HEADERS, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_EXPOSE_HEADERS should be a sequence.",
+                id="corsheaders.E008"
+            )
+        )
+
+    if not isinstance(conf.CORS_URLS_REGEX, six.string_types + (re_type,)):
+        errors.append(
+            checks.Error(
+                "CORS_URLS_REGEX should be a string or regex.",
+                id="corsheaders.E009"
+            )
+        )
+
+    if conf.CORS_MODEL is not None and not isinstance(conf.CORS_MODEL, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_MODEL should be a string or None.",
+                id="corsheaders.E010"
+            )
+        )
+
+    if not isinstance(conf.CORS_REPLACE_HTTPS_REFERER, bool):
+        errors.append(
+            checks.Error(
+                "CORS_REPLACE_HTTPS_REFERER should be a bool.",
+                id="corsheaders.E011"
+            )
+        )
+
+    if not isinstance(conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL, bool):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_CREDENTIALS_ALLOW_ALL should be a bool.",
+                id="corsheaders.E012"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_WHITELIST, six.string_types):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_CREDENTIALS_WHITELIST should be a sequence of strings.",
+                id="corsheaders.E013"
+            )
+        )
+
+    if not is_sequence(conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST, six.string_types + (re_type,)):
+        errors.append(
+            checks.Error(
+                "CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
+                id="corsheaders.E014"
+            )
+        )
 
     return errors
 

--- a/corsheaders/conf.py
+++ b/corsheaders/conf.py
@@ -54,5 +54,17 @@ class Settings(object):
     def CORS_REPLACE_HTTPS_REFERER(self):
         return getattr(settings, 'CORS_REPLACE_HTTPS_REFERER', False)
 
+    @property
+    def CORS_ORIGIN_CREDENTIALS_ALLOW_ALL(self):
+        return getattr(settings, 'CORS_ORIGIN_CREDENTIALS_ALLOW_ALL', True)
+
+    @property
+    def CORS_ORIGIN_CREDENTIALS_WHITELIST(self):
+        return getattr(settings, 'CORS_ORIGIN_CREDENTIALS_WHITELIST', ())
+
+    @property
+    def CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST(self):
+        return getattr(settings, 'CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST', ())
+
 
 conf = Settings()

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -118,8 +118,8 @@ class CorsMiddleware(MiddlewareMixin):
 
         if (
             conf.CORS_ALLOW_CREDENTIALS and (
-                conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL or
-                self.origin_found_in_credentials_white_lists(origin, url)
+                conf.CORS_ORIGIN_CREDENTIALS_ALLOW_ALL
+                or self.origin_found_in_credentials_white_lists(origin, url)
             )
         ):
             response[ACCESS_CONTROL_ALLOW_CREDENTIALS] = 'true'
@@ -150,9 +150,9 @@ class CorsMiddleware(MiddlewareMixin):
 
     def origin_found_in_credentials_white_lists(self, origin, url):
         return (
-            url.netloc in conf.CORS_ORIGIN_CREDENTIALS_WHITELIST or
-            (origin == 'null' and origin in conf.CORS_ORIGIN_CREDENTIALS_WHITELIST) or
-            self.regex_domain_match(origin, conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST)
+            url.netloc in conf.CORS_ORIGIN_CREDENTIALS_WHITELIST
+            or (origin == 'null' and origin in conf.CORS_ORIGIN_CREDENTIALS_WHITELIST)
+            or self.regex_domain_match(origin, conf.CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST)
         )
 
     def origin_found_in_white_lists(self, origin, url):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -97,3 +97,23 @@ class ChecksTests(SimpleTestCase):
     @override_settings(CORS_REPLACE_HTTPS_REFERER=object)
     def test_cors_replace_https_referer_failure(self):
         self.check_error_codes(['corsheaders.E011'])
+
+    @override_settings(CORS_ORIGIN_CREDENTIALS_ALLOW_ALL=object)
+    def test_cors_origin_credentials_allow_all_non_bool(self):
+        self.check_error_codes(['corsheaders.E012'])
+
+    @override_settings(CORS_ORIGIN_CREDENTIALS_WHITELIST=object)
+    def test_cors_origin_credentials_whitelist_non_sequence(self):
+        self.check_error_codes(['corsheaders.E013'])
+
+    @override_settings(CORS_ORIGIN_CREDENTIALS_WHITELIST=[object])
+    def test_cors_origin_credentials_whitelist_non_string(self):
+        self.check_error_codes(['corsheaders.E013'])
+
+    @override_settings(CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST=object)
+    def test_cors_origin_credentials_regex_whitelist_non_sequence(self):
+        self.check_error_codes(['corsheaders.E014'])
+
+    @override_settings(CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST=[re.compile(r'a')])
+    def test_cors_origin_credentials_regex_whitelist_regex(self):
+        self.check_error_codes([])

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -3,18 +3,16 @@ from __future__ import absolute_import
 import re
 
 import pytest
-from django.core.checks import Error
+from django.core.checks import Error, run_checks
 from django.core.management import base, call_command
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-
-from corsheaders.checks import check_settings
 
 
 class ChecksTests(SimpleTestCase):
 
     def check_error_codes(self, expected):
-        errors = check_settings([])
+        errors = run_checks()
         assert len(errors) == len(expected)
         assert all(isinstance(e, Error) for e in errors)
         assert [e.id for e in errors] == expected

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -63,8 +63,37 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
         assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == 'true'
 
+    @override_settings(
+        CORS_ALLOW_CREDENTIALS=True,
+        CORS_ORIGIN_CREDENTIALS_ALLOW_ALL=False,
+        CORS_ORIGIN_CREDENTIALS_WHITELIST=('localhost',),
+        CORS_ORIGIN_ALLOW_ALL=True,
+    )
+    def test_get_allow_credentials_whitelist(self):
+        resp = self.client.get('/', HTTP_ORIGIN='http://localhost')
+        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == 'true'
+
+    @override_settings(
+        CORS_ALLOW_CREDENTIALS=True,
+        CORS_ORIGIN_CREDENTIALS_ALLOW_ALL=False,
+        CORS_ORIGIN_CREDENTIALS_REGEX_WHITELIST=(r'^http?://localhost$',),
+        CORS_ORIGIN_ALLOW_ALL=True,
+    )
+    def test_get_allow_credentials_regex_whitelist(self):
+        resp = self.client.get('/', HTTP_ORIGIN='http://localhost')
+        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == 'true'
+
     @override_settings(CORS_ORIGIN_ALLOW_ALL=True)
     def test_get_dont_allow_credentials(self):
+        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
+
+    @override_settings(
+        CORS_ALLOW_CREDENTIALS=True,
+        CORS_ORIGIN_CREDENTIALS_ALLOW_ALL=False,
+        CORS_ORIGIN_ALLOW_ALL=True,
+    )
+    def test_get_dont_allow_credentials_for_all(self):
         resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
         assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
 


### PR DESCRIPTION
Currently, there is no option to limit `Access-Control-Allow-Credentials` to specific domains.
This PR introduces support for whitelists specific to `Access-Control-Allow-Credentials` header.
It does not break backwards compatibility, as `CORS_ORIGIN_CREDENTIALS_ALLOW_ALL` is set to True by default.