### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ notifications:
   email: false
 
 language: python
-python: '3.6'
+python:
+  - '3.6'
+  - '3.7'
 cache: pip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ notifications:
 
 language: python
 python:
-  - '3.6'
-  - '3.7'
+- 3.5
+- 3.6
+- 3.7
 cache: pip
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 2.7, 3.7
+* Python: 2.7, 3.5, 3.6, 3.7
 * Django: 1.11, 2.0, 2.1, 2.2
 
 Setup

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 2.7, 3.6
+* Python: 2.7, 3.7
 * Django: 1.11, 2.0, 2.1, 2.2
 
 Setup

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],


### PR DESCRIPTION
[`dist: xenial` is needed for Python 3.7+](https://github.com/travis-ci/travis-ci/issues/9815)

Related question: Should `'Programming Language :: Python :: 3.5',` be dropped from `setup.py` since it isn't tested on CI? Or should we also add 3.5 to the Travis matrix so that support is actually maintained/guaranteed?