### PR TITLE
Add 'access-control-allow-origin' to default_headers for supporting pre-flight requests

### DIFF
--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -8,6 +8,7 @@ default_headers = (
     'user-agent',
     'x-csrftoken',
     'x-requested-with',
+    'access-control-allow-origin',
 )
 
 default_methods = (


### PR DESCRIPTION
In order to reply to `OPTIONS` requests, 'access-control-allow-origin' should be in 'default_headers'.

This would then work for all the pre-flight requests through AJAX.