### PR TITLE
Fix DeprecationWarning from collections.abc.Sequence on Python 3.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Pending
 
 .. Insert new release notes below this line
 
+* Fix ``DeprecationWarning`` from importing ``collections.abc.Sequence`` on
+  Python 3.7.
+
 2.4.0 (2018-07-18)
 ------------------
 

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -1,13 +1,17 @@
 from __future__ import absolute_import
 
 import re
-from collections import Sequence
 from numbers import Integral
 
 from django.core import checks
 from django.utils import six
 
 from .conf import conf
+
+try:
+    from collections.abc import Sequence  # Python 3.3+
+except ImportError:  # pragma: no cover
+    from collections import Sequence
 
 re_type = type(re.compile(''))
 


### PR DESCRIPTION
Fixes #374.