### PR TITLE
Remove support for Django 1.8, 1.9, and 1.10

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Pending
 
 .. Insert new release notes below this line
 
+* Drop Django 1.8, 1.9, and 1.10 support. Only Django 1.11+ is supported now.
+
 2.4.1 (2019-02-28)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Requirements
 Tested with all combinations of:
 
 * Python: 2.7, 3.6
-* Django: 1.8, 1.9, 1.10, 1.11, 2.0, 2.1
+* Django: 1.11, 2.0, 2.1
 
 Setup
 -----

--- a/corsheaders/compat.py
+++ b/corsheaders/compat.py
@@ -1,8 +1,0 @@
-from __future__ import absolute_import
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:  # pragma: no cover
-    # Not required for Django <= 1.9, see:
-    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
-    MiddlewareMixin = object  # pragma: no cover

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -5,9 +5,9 @@ import re
 from django import http
 from django.apps import apps
 from django.utils.cache import patch_vary_headers
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.six.moves.urllib.parse import urlparse
 
-from .compat import MiddlewareMixin
 from .conf import conf
 from .signals import check_request_enabled
 

--- a/setup.py
+++ b/setup.py
@@ -35,15 +35,14 @@ setup(
     packages=['corsheaders'],
     license='MIT License',
     keywords=['django', 'cors', 'middleware', 'rest', 'api'],
-    install_requires=[],
+    install_requires=[
+        'Django>=1.11',
+    ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 
-import django
-from django.conf import global_settings
-
 SECRET_KEY = 'NOTASECRET'
 
 ALLOWED_HOSTS = ['*']
@@ -26,16 +23,8 @@ TEMPLATES = [
 
 ROOT_URLCONF = 'tests.urls'
 
-if django.VERSION >= (2, 0):
-    middlewares = list(global_settings.MIDDLEWARE)
-else:
-    middlewares = list(global_settings.MIDDLEWARE_CLASSES)
-
-middlewares.append('corsheaders.middleware.CorsMiddleware')
-
-if django.VERSION >= (1, 10):
-    MIDDLEWARE = middlewares
-else:
-    MIDDLEWARE_CLASSES = middlewares
+MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
+]
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_FAKE_SECURE', 'true')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
-import django
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils.deprecation import MiddlewareMixin
 
-from corsheaders.compat import MiddlewareMixin
 from corsheaders.middleware import (
     ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
     ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE
@@ -301,15 +300,10 @@ class CorsMiddlewareTests(TestCase):
         Test a scenario when a middleware that returns a response is run before
         the ``CorsMiddleware``. In this case
         ``CorsMiddleware.process_response()`` should ignore the request if
-        MIDDLEWARE setting is used (new mechanism in Django 1.10+) and process
-        the request and add CORS response headers if MIDDLEWARE_CLASSES is
-        used in a backward compatible fashion with django-cors-headers pre 1.3.0.
+        MIDDLEWARE setting is used (new mechanism in Django 1.10+).
         """
         resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
-        if django.VERSION[:2] >= (1, 10):
-            assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
-        else:
-            assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
+        assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
         CORS_ORIGIN_WHITELIST=['example.com'],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,20 +2,14 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 
-import django
 from django.test.utils import modify_settings
 
 from corsheaders.signals import check_request_enabled
 
 
 def add_middleware(action, path):
-    if django.VERSION[:2] >= (1, 10):
-        middleware_setting = 'MIDDLEWARE'
-    else:
-        middleware_setting = 'MIDDLEWARE_CLASSES'
-
     return modify_settings(**{
-        middleware_setting: {
+        'MIDDLEWARE': {
             action: path,
         }
     })

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,3}-django{18,19,110,111},
+    py{27,3}-django{111},
     py3-django{20,21},
     py{27,3}-codestyle
 
@@ -10,9 +10,6 @@ setenv =
 install_command = pip install --no-deps {opts} {packages}
 deps =
     -rrequirements.txt
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2


### PR DESCRIPTION
* `HISTORY.rst` - add note
* `README.rst` - update list of tested versions
* `tox.ini` - update test grid
* `setup.py` - specify Django version in `install_requires`, remove classifiers
* Remove `compat` module and always import `MiddlewareMixin`, update code to always use `MIDDLEWARE` instead of `MIDDLEWARE_CLASSES`