### PR TITLE
MANIFEST.in: Add test infrastructure to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include HISTORY.rst README.rst
 include LICENSE
+include runtests.py tox.ini pytest.ini requirements.txt
+graft tests


### PR DESCRIPTION
Allow sdist consumers to reliably reproduce the tests with
dependencies as tested at release time.

Closes https://github.com/ottoyiu/django-cors-headers/issues/369