### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Pending
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 3.0.0 (2019-05-10)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,10 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 2.7, 3.5, 3.6, 3.7
+* Python: 3.6
 * Django: 1.11, 2.0, 2.1, 2.2
+
+Python 3.4+ supported.
 
 Setup
 -----

--- a/corsheaders/__init__.py
+++ b/corsheaders/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from corsheaders.checks import check_settings  # noqa: F401
 
 __version__ = '3.0.0'

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -1,19 +1,12 @@
-from __future__ import absolute_import
-
 import re
+from collections.abc import Sequence
 from numbers import Integral
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core import checks
-from django.utils import six
-from django.utils.six.moves.urllib.parse import urlparse
 
 from corsheaders.conf import conf
-
-try:
-    from collections.abc import Sequence  # Python 3.3+
-except ImportError:  # pragma: no cover
-    from collections import Sequence
 
 re_type = type(re.compile(''))
 
@@ -22,7 +15,7 @@ re_type = type(re.compile(''))
 def check_settings(app_configs, **kwargs):
     errors = []
 
-    if not is_sequence(conf.CORS_ALLOW_HEADERS, six.string_types):
+    if not is_sequence(conf.CORS_ALLOW_HEADERS, str):
         errors.append(
             checks.Error(
                 "CORS_ALLOW_HEADERS should be a sequence of strings.",
@@ -30,7 +23,7 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
-    if not is_sequence(conf.CORS_ALLOW_METHODS, six.string_types):
+    if not is_sequence(conf.CORS_ALLOW_METHODS, str):
         errors.append(
             checks.Error(
                 "CORS_ALLOW_METHODS should be a sequence of strings.",
@@ -62,7 +55,7 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
-    if not is_sequence(conf.CORS_ORIGIN_WHITELIST, six.string_types):
+    if not is_sequence(conf.CORS_ORIGIN_WHITELIST, str):
         errors.append(
             checks.Error(
                 "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
@@ -86,7 +79,7 @@ def check_settings(app_configs, **kwargs):
                             id="corsheaders.E014"
                         ))
 
-    if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, six.string_types + (re_type,)):
+    if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, (str, re_type)):
         errors.append(
             checks.Error(
                 "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
@@ -94,7 +87,7 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
-    if not is_sequence(conf.CORS_EXPOSE_HEADERS, six.string_types):
+    if not is_sequence(conf.CORS_EXPOSE_HEADERS, str):
         errors.append(
             checks.Error(
                 "CORS_EXPOSE_HEADERS should be a sequence.",
@@ -102,7 +95,7 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
-    if not isinstance(conf.CORS_URLS_REGEX, six.string_types + (re_type,)):
+    if not isinstance(conf.CORS_URLS_REGEX, (str, re_type)):
         errors.append(
             checks.Error(
                 "CORS_URLS_REGEX should be a string or regex.",
@@ -129,8 +122,8 @@ def check_settings(app_configs, **kwargs):
     return errors
 
 
-def is_sequence(thing, types):
+def is_sequence(thing, type_or_types):
     return (
         isinstance(thing, Sequence)
-        and all(isinstance(x, types) for x in thing)
+        and all(isinstance(x, type_or_types) for x in thing)
     )

--- a/corsheaders/conf.py
+++ b/corsheaders/conf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.conf import settings
 
 from corsheaders.defaults import default_headers, default_methods  # Kept here for backwards compatibility

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -1,11 +1,9 @@
-from __future__ import absolute_import
-
 import re
+from urllib.parse import urlparse
 
 from django import http
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.six.moves.urllib.parse import urlparse
 
 from corsheaders.conf import conf
 from corsheaders.signals import check_request_enabled

--- a/corsheaders/signals.py
+++ b/corsheaders/signals.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.dispatch import Signal
 
 # If any attached handler returns Truthy, CORS will be allowed for the request.

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,6 @@
 docutils
 flake8
-futures<3.2.0
 isort
-modernize
 multilint
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,22 +6,15 @@
 #
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-backports.functools-lru-cache==1.5 ; python_version < '3.0'  # via isort
-configparser==3.7.4       # via entrypoints, flake8
 coverage==4.5.3           # via pytest-cov
 docutils==0.14
 entrypoints==0.3          # via flake8
-enum34==1.1.6             # via flake8
 flake8==3.7.7
-funcsigs==1.0.2           # via pytest
-functools32==3.2.3.post2 ; python_version < '3.0'  # via flake8
-futures==3.1.1
 isort==4.3.18
 mccabe==0.6.1             # via flake8
-modernize==0.7
-more-itertools==5.0.0     # via pytest
+more-itertools==7.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via pytest
 pluggy==0.11.0            # via pytest
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
@@ -29,9 +22,7 @@ pyflakes==2.1.1           # via flake8
 pygments==2.4.0
 pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.4.2
 pytz==2019.1
-scandir==1.10.0           # via pathlib2
-six==1.12.0               # via more-itertools, multilint, pathlib2, pytest
+six==1.12.0               # via multilint, pathlib2, pytest
 sqlparse==0.3.0
-typing==3.6.6             # via flake8

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore = X99999, W503, C901
 max-complexity = 12

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-import codecs
 import os
 import re
 
@@ -8,17 +5,17 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version(os.path.join('corsheaders', '__init__.py'))
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 setup(
@@ -38,7 +35,7 @@ setup(
     install_requires=[
         'Django>=1.11',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -51,8 +48,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 SECRET_KEY = 'NOTASECRET'
 
 ALLOWED_HOSTS = ['*']

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 
 import pytest

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.conf.urls import url
 from django.http import Http404, HttpResponse
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from contextlib import contextmanager
 
 from django.test.utils import modify_settings

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py{27,3}-django{111},
-    py3-django{20,21,22},
-    py{27,3}-codestyle
+    py3-django{111,20,21,22},
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -15,11 +14,6 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
 commands = ./runtests.py {posargs}
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin and `modernize`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove universal wheel building