### PR TITLE
MANIFEST.in: Fine tune test inclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include HISTORY.rst README.rst
 include LICENSE
 include runtests.py tox.ini pytest.ini requirements.txt
-graft tests
+recursive-include tests *.py


### PR DESCRIPTION
This avoids `*.py[co]` and `__pycache__` from being included.