### PR TITLE
Improve MANIFEST.in exclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include HISTORY.rst README.rst
 include LICENSE
 include runtests.py tox.ini pytest.ini requirements.txt
-recursive-include tests *.py
+graft tests
+global-exclude *.py[cod] __pycache__


### PR DESCRIPTION
Improve up on the change in #382 to make sure that no pyc files are included from anywhere, and other files that might get added in the test directory in future would get included automatically.