### PR TITLE
refactor(conf): Use property descriptor to simplify Settings class

### DIFF
--- a/corsheaders/conf.py
+++ b/corsheaders/conf.py
@@ -4,55 +4,43 @@ from django.conf import settings
 
 from .defaults import default_headers, default_methods  # Kept here for backwards compatibility
 
+class _Setting(object):
+    def __init__(self,key,default):
+        self.key = key
+        self.default = default
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return getattr(settings,self.key, self.default)
+
 
 class Settings(object):
     """
     Shadow Django's settings with a little logic
     """
 
-    @property
-    def CORS_ALLOW_HEADERS(self):
-        return getattr(settings, 'CORS_ALLOW_HEADERS', default_headers)
+    CORS_ALLOW_HEADERS = _Setting('CORS_ALLOW_HEADERS', default_headers)
 
-    @property
-    def CORS_ALLOW_METHODS(self):
-        return getattr(settings, 'CORS_ALLOW_METHODS', default_methods)
+    CORS_ALLOW_METHODS = _Setting('CORS_ALLOW_METHODS', default_methods)
 
-    @property
-    def CORS_ALLOW_CREDENTIALS(self):
-        return getattr(settings, 'CORS_ALLOW_CREDENTIALS', False)
+    CORS_ALLOW_CREDENTIALS  = _Setting('CORS_ALLOW_CREDENTIALS', False)
 
-    @property
-    def CORS_PREFLIGHT_MAX_AGE(self):
-        return getattr(settings, 'CORS_PREFLIGHT_MAX_AGE', 86400)
+    CORS_PREFLIGHT_MAX_AGE  = _Setting('CORS_PREFLIGHT_MAX_AGE', 86400)
 
-    @property
-    def CORS_ORIGIN_ALLOW_ALL(self):
-        return getattr(settings, 'CORS_ORIGIN_ALLOW_ALL', False)
+    CORS_ORIGIN_ALLOW_ALL  = _Setting('CORS_ORIGIN_ALLOW_ALL', False)
 
-    @property
-    def CORS_ORIGIN_WHITELIST(self):
-        return getattr(settings, 'CORS_ORIGIN_WHITELIST', ())
+    CORS_ORIGIN_WHITELIST = _Setting('CORS_ORIGIN_WHITELIST', ())
 
-    @property
-    def CORS_ORIGIN_REGEX_WHITELIST(self):
-        return getattr(settings, 'CORS_ORIGIN_REGEX_WHITELIST', ())
+    CORS_ORIGIN_REGEX_WHITELIST = _Setting('CORS_ORIGIN_REGEX_WHITELIST', ())
 
-    @property
-    def CORS_EXPOSE_HEADERS(self):
-        return getattr(settings, 'CORS_EXPOSE_HEADERS', ())
+    CORS_EXPOSE_HEADERS = _Setting('CORS_EXPOSE_HEADERS', ())
 
-    @property
-    def CORS_URLS_REGEX(self):
-        return getattr(settings, 'CORS_URLS_REGEX', r'^.*$')
+    CORS_URLS_REGEX = _Setting('CORS_URLS_REGEX', r'^.*$')
 
-    @property
-    def CORS_MODEL(self):
-        return getattr(settings, 'CORS_MODEL', None)
+    CORS_MODEL = _Setting('CORS_MODEL', None)
 
-    @property
-    def CORS_REPLACE_HTTPS_REFERER(self):
-        return getattr(settings, 'CORS_REPLACE_HTTPS_REFERER', False)
+    CORS_REPLACE_HTTPS_REFERER = _Setting('CORS_REPLACE_HTTPS_REFERER', False)
 
 
 conf = Settings()


### PR DESCRIPTION
we can use python's property descriptor to simplify Settings class and reduce duplicate code.