### PR TITLE
Require scheme in origins

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,15 +6,34 @@ Pending
 
 .. Insert new release notes below this line
 
-* Origin is now scheme-aware. Deprecation warning has been added when origin
-  without scheme is included.
+* ``CORS_ORIGIN_WHITELIST`` now requires URI schemes, and optionally ports.
+  This is part of the CORS specification
+  (`Section 3.2 <https://tools.ietf.org/html/rfc6454#section-3.2>`_) that was
+  not implemented in this library, except from with the
+  ``CORS_ORIGIN_REGEX_WHITELIST`` setting. It fixes a security issue where the
+  CORS middleware would allow requests between schemes, for example from
+  insecure ``http://`` Origins to a secure ``https://`` site.
+
+  You will need to update your whitelist to include schemes, for example from
+  this:
+
+  .. code-block:: python
+
+      CORS_ORIGIN_WHITELIST = ['example.com']
+
+  ...to this:
+
+  .. code-block:: python
+
+      CORS_ORIGIN_WHITELIST = ['https://example.com']
+
 * Removed the ``CORS_MODEL`` setting, and associated class. It seems very few,
   or no users were using it, since there were no bug reports since its move to
   abstract in version 2.0.0 (2017-01-07). If you *are* using this
   functionality, you can continue by changing your model to not inherit from
   the abstract one, and add a signal handler for ``check_request_enabled`` that
-  reads from your model. Note you'll need to handle the move to scheme-aware
-  values for Origin.
+  reads from your model. Note you'll need to handle the move to include schemes
+  for Origins.
 
 2.5.3 (2019-04-28)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -95,40 +95,44 @@ Defaults to ``False``.
 ``CORS_ORIGIN_WHITELIST``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A list of origin hostnames that are authorized to make cross-site HTTP
-requests. The value ``'null'`` can also appear in this list, and will match the
-``Origin: null`` header that is used in `"privacy-sensitive contexts"
-<https://tools.ietf.org/html/rfc6454#section-6>`_, such as when the client is
-running from a ``file://`` domain. Defaults to ``[]``. Proper origin should consist of
-scheme, host and port (which could be given implicitly, e.g. for http it is assumed that the port is
-80). Skipping scheme is allowed only for backward compatibility, deprecation warning will be raised
-if this is discovered.
+A list of origins that are authorized to make cross-site HTTP requests.
+Defaults to ``[]``.
+
+An Origin is defined by
+`the CORS RFC Section 3.2 <https://tools.ietf.org/html/rfc6454#section-3.2>`_
+as a URI scheme + hostname + port, or the special value `'null'`.
+Default ports (HTTPS = 443, HTTP = 80) are optional here.
+The special value `null` is sent by the browser in
+`"privacy-sensitive contexts" <https://tools.ietf.org/html/rfc6454#section-6>`_,
+such as when the client is running from a ``file://`` domain.
 
 Example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_WHITELIST = (
-        'https://google.com',
-        'http://hostname.example.com',
-        'http://localhost:8000',
-        'http://127.0.0.1:9000'
+    CORS_ORIGIN_WHITELIST = [
+        "https://example.com",
+        "https://sub.example.com",
+        "http://localhost:8080",
+        "http://127.0.0.1:9000"
     )
 
 
 ``CORS_ORIGIN_REGEX_WHITELIST``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A list of regexes that match origin regex list of origin hostnames that are
-authorized to make cross-site HTTP requests. Defaults to ``[]``. Useful when
-``CORS_ORIGIN_WHITELIST`` is impractical, such as when you have a large
-number of subdomains.
+A list of strings representing regexes that match Origins that are authorized
+to make cross-site HTTP requests. Defaults to ``[]``. Useful when
+``CORS_ORIGIN_WHITELIST`` is impractical, such as when you have a large number
+of subdomains.
 
 Example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_REGEX_WHITELIST = (r'^(https?://)?(\w+\.)?google\.com$', )
+    CORS_ORIGIN_REGEX_WHITELIST = [
+        r"^https://\w+\.example\.com$",
+    ]
 
 --------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-ignore = X99999, W503
+ignore = X99999, W503, C901
 max-complexity = 12
 max-line-length = 120
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -70,6 +70,18 @@ class ChecksTests(SimpleTestCase):
     def test_cors_origin_whitelist_non_string(self):
         self.check_error_codes(['corsheaders.E006'])
 
+    @override_settings(CORS_ORIGIN_WHITELIST=['example.com'])
+    def test_cors_origin_whitelist_no_scheme(self):
+        self.check_error_codes(['corsheaders.E013'])
+
+    @override_settings(CORS_ORIGIN_WHITELIST=['https://'])
+    def test_cors_origin_whitelist_no_netloc(self):
+        self.check_error_codes(['corsheaders.E013'])
+
+    @override_settings(CORS_ORIGIN_WHITELIST=['https://example.com/foobar'])
+    def test_cors_origin_whitelist_path(self):
+        self.check_error_codes(['corsheaders.E014'])
+
     @override_settings(CORS_ORIGIN_REGEX_WHITELIST=object)
     def test_cors_origin_regex_whitelist_non_sequence(self):
         self.check_error_codes(['corsheaders.E007'])

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import warnings
-
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -40,15 +38,6 @@ class CorsMiddlewareTests(TestCase):
     def test_get_not_in_whitelist_due_to_wrong_scheme(self):
         resp = self.client.get('/', HTTP_ORIGIN='http://example.org')
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
-
-    @override_settings(CORS_ORIGIN_WHITELIST=['example.org'])
-    def test_get_without_scheme_in_whitelist_raises_warning(self):
-        with warnings.catch_warnings(record=True) as warn:
-            resp = self.client.get('/', HTTP_ORIGIN='http://example.org')
-            assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
-            assert len(warn) == 1
-            assert issubclass(warn[-1].category, DeprecationWarning)
-            assert 'Passing origins without scheme will be deprecated.' in str(warn[-1].message)
 
     @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com', 'http://example.org'])
     def test_get_in_whitelist(self):
@@ -116,7 +105,7 @@ class CorsMiddlewareTests(TestCase):
     @override_settings(
         CORS_ALLOW_METHODS=['OPTIONS'],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_WHITELIST=('http://localhost:9000',),
+        CORS_ORIGIN_WHITELIST=['http://localhost:9000'],
     )
     def test_options_whitelist_with_port(self):
         resp = self.client.options('/', HTTP_ORIGIN='http://localhost:9000')


### PR DESCRIPTION
This "upgrades" the change in #388 to *require* scheme, rather than going through a deprecation period. It simplifies the code greatly.

I added checks as well to ensure that `CORS_ORIGIN_WHITELIST` is well-formed, so that users upgrading will see some obvious errors.