### PR TITLE
Remove relative imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -314,7 +314,7 @@ For example you might define a handler like this:
     # myapp/handlers.py
     from corsheaders.signals import check_request_enabled
 
-    from .models import MySite
+    from myapp.models import MySite
 
     def cors_allow_mysites(sender, request, **kwargs):
         return MySite.objects.filter(host=request.host).exists()
@@ -341,7 +341,7 @@ Then connect it at app ready time using a `Django AppConfig
 
         def ready(self):
             # Makes sure all signal handlers are connected
-            from . import handlers  # noqa
+            from myapp import handlers  # noqa
 
 
 A common use case for the signal is to allow *all* origins to access a subset

--- a/corsheaders/__init__.py
+++ b/corsheaders/__init__.py
@@ -1,3 +1,5 @@
-from .checks import check_settings  # noqa: F401
+from __future__ import absolute_import
+
+from corsheaders.checks import check_settings  # noqa: F401
 
 __version__ = '2.5.3'

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -8,7 +8,7 @@ from django.core import checks
 from django.utils import six
 from django.utils.six.moves.urllib.parse import urlparse
 
-from .conf import conf
+from corsheaders.conf import conf
 
 try:
     from collections.abc import Sequence  # Python 3.3+

--- a/corsheaders/conf.py
+++ b/corsheaders/conf.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 
-from .defaults import default_headers, default_methods  # Kept here for backwards compatibility
+from corsheaders.defaults import default_headers, default_methods  # Kept here for backwards compatibility
 
 
 class Settings(object):

--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -7,8 +7,8 @@ from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.six.moves.urllib.parse import urlparse
 
-from .conf import conf
-from .signals import check_request_enabled
+from corsheaders.conf import conf
+from corsheaders.signals import check_request_enabled
 
 ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
 ACCESS_CONTROL_EXPOSE_HEADERS = 'Access-Control-Expose-Headers'

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,8 +9,7 @@ from corsheaders.middleware import (
     ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
     ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE
 )
-
-from .utils import append_middleware, prepend_middleware, temporary_check_request_hander
+from tests.utils import append_middleware, prepend_middleware, temporary_check_request_hander
 
 
 class ShortCircuitMiddleware(MiddlewareMixin):


### PR DESCRIPTION
In my experience these can lead to subtle bugs when PYTHONPATH is messed with, it's best to be explicit.