### PR TITLE
Allow 'null' in CORS_ORIGIN_WHITELIST check (#405)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Pending
 
 .. Insert new release notes below this line
 
+* Allow 'null' in ``CORS_ORIGIN_WHITELIST`` check.
+
 3.0.0 (2019-05-10)
 ------------------
 

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -71,6 +71,8 @@ def check_settings(app_configs, **kwargs):
         )
     else:
         for origin in conf.CORS_ORIGIN_WHITELIST:
+            if origin == 'null':
+                continue
             parsed = urlparse(origin)
             if parsed.scheme == '' or parsed.netloc == '':
                 errors.append(checks.Error(

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -70,6 +70,10 @@ class ChecksTests(SimpleTestCase):
     def test_cors_origin_whitelist_non_string(self):
         self.check_error_codes(['corsheaders.E006'])
 
+    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com', 'null'])
+    def test_cors_origin_whitelist_allowed(self):
+        self.check_error_codes([])
+
     @override_settings(CORS_ORIGIN_WHITELIST=['example.com'])
     def test_cors_origin_whitelist_no_scheme(self):
         self.check_error_codes(['corsheaders.E013'])


### PR DESCRIPTION
Fixes #404.