### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ django-cors-headers
 .. image:: https://img.shields.io/pypi/v/django-cors-headers.svg
     :target: https://pypi.python.org/pypi/django-cors-headers/
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 A Django App that adds Cross-Origin Resource Sharing (CORS) headers to
 responses. This allows in-browser requests to your Django application from
 other origins.

--- a/corsheaders/__init__.py
+++ b/corsheaders/__init__.py
@@ -1,3 +1,3 @@
 from corsheaders.checks import check_settings  # noqa: F401
 
-__version__ = '3.0.2'
+__version__ = "3.0.2"

--- a/corsheaders/checks.py
+++ b/corsheaders/checks.py
@@ -8,7 +8,7 @@ from django.core import checks
 
 from corsheaders.conf import conf
 
-re_type = type(re.compile(''))
+re_type = type(re.compile(""))
 
 
 @checks.register
@@ -19,7 +19,7 @@ def check_settings(app_configs, **kwargs):
         errors.append(
             checks.Error(
                 "CORS_ALLOW_HEADERS should be a sequence of strings.",
-                id="corsheaders.E001"
+                id="corsheaders.E001",
             )
         )
 
@@ -27,31 +27,35 @@ def check_settings(app_configs, **kwargs):
         errors.append(
             checks.Error(
                 "CORS_ALLOW_METHODS should be a sequence of strings.",
-                id="corsheaders.E002"
+                id="corsheaders.E002",
             )
         )
 
     if not isinstance(conf.CORS_ALLOW_CREDENTIALS, bool):
         errors.append(
             checks.Error(
-                "CORS_ALLOW_CREDENTIALS should be a bool.",
-                id="corsheaders.E003"
+                "CORS_ALLOW_CREDENTIALS should be a bool.", id="corsheaders.E003"
             )
         )
 
-    if not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral) or conf.CORS_PREFLIGHT_MAX_AGE < 0:
+    if (
+        not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, Integral)
+        or conf.CORS_PREFLIGHT_MAX_AGE < 0
+    ):
         errors.append(
             checks.Error(
-                "CORS_PREFLIGHT_MAX_AGE should be an integer greater than or equal to zero.",
-                id="corsheaders.E004"
+                (
+                    "CORS_PREFLIGHT_MAX_AGE should be an integer greater than "
+                    + "or equal to zero."
+                ),
+                id="corsheaders.E004",
             )
         )
 
     if not isinstance(conf.CORS_ORIGIN_ALLOW_ALL, bool):
         errors.append(
             checks.Error(
-                "CORS_ORIGIN_ALLOW_ALL should be a bool.",
-                id="corsheaders.E005"
+                "CORS_ORIGIN_ALLOW_ALL should be a bool.", id="corsheaders.E005"
             )
         )
 
@@ -59,66 +63,83 @@ def check_settings(app_configs, **kwargs):
         errors.append(
             checks.Error(
                 "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
-                id="corsheaders.E006"
+                id="corsheaders.E006",
             )
         )
     else:
         for origin in conf.CORS_ORIGIN_WHITELIST:
-            if origin == 'null':
+            if origin == "null":
                 continue
             parsed = urlparse(origin)
-            if parsed.scheme == '' or parsed.netloc == '':
-                errors.append(checks.Error(
-                    "Origin {} in CORS_ORIGIN_WHITELIST is missing scheme or netloc".format(repr(origin)),
-                    id="corsheaders.E013",
-                    hint="Add a scheme (e.g. https://) or netloc (e.g. example.com)."
-                ))
+            if parsed.scheme == "" or parsed.netloc == "":
+                errors.append(
+                    checks.Error(
+                        (
+                            "Origin {} in CORS_ORIGIN_WHITELIST is missing "
+                            + " scheme or netloc"
+                        ).format(repr(origin)),
+                        id="corsheaders.E013",
+                        hint=(
+                            "Add a scheme (e.g. https://) or netloc (e.g. "
+                            + "example.com)."
+                        ),
+                    )
+                )
             else:
-                # Only do this check in this case because if the scheme is not provided, netloc ends up in path
-                for part in ('path', 'params', 'query', 'fragment'):
-                    if getattr(parsed, part) != '':
-                        errors.append(checks.Error(
-                            "Origin {} in CORS_ORIGIN_WHITELIST should not have {}".format(repr(origin), part),
-                            id="corsheaders.E014"
-                        ))
+                # Only do this check in this case because if the scheme is not
+                # provided, netloc ends up in path
+                for part in ("path", "params", "query", "fragment"):
+                    if getattr(parsed, part) != "":
+                        errors.append(
+                            checks.Error(
+                                (
+                                    "Origin {} in CORS_ORIGIN_WHITELIST should "
+                                    + "not have {}"
+                                ).format(repr(origin), part),
+                                id="corsheaders.E014",
+                            )
+                        )
 
     if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, (str, re_type)):
         errors.append(
             checks.Error(
-                "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of strings and/or compiled regexes.",
-                id="corsheaders.E007"
+                (
+                    "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of "
+                    + "strings and/or compiled regexes."
+                ),
+                id="corsheaders.E007",
             )
         )
 
     if not is_sequence(conf.CORS_EXPOSE_HEADERS, str):
         errors.append(
             checks.Error(
-                "CORS_EXPOSE_HEADERS should be a sequence.",
-                id="corsheaders.E008"
+                "CORS_EXPOSE_HEADERS should be a sequence.", id="corsheaders.E008"
             )
         )
 
     if not isinstance(conf.CORS_URLS_REGEX, (str, re_type)):
         errors.append(
             checks.Error(
-                "CORS_URLS_REGEX should be a string or regex.",
-                id="corsheaders.E009"
+                "CORS_URLS_REGEX should be a string or regex.", id="corsheaders.E009"
             )
         )
 
     if not isinstance(conf.CORS_REPLACE_HTTPS_REFERER, bool):
         errors.append(
             checks.Error(
-                "CORS_REPLACE_HTTPS_REFERER should be a bool.",
-                id="corsheaders.E011"
+                "CORS_REPLACE_HTTPS_REFERER should be a bool.", id="corsheaders.E011"
             )
         )
 
-    if hasattr(settings, 'CORS_MODEL'):
+    if hasattr(settings, "CORS_MODEL"):
         errors.append(
             checks.Error(
-                "The CORS_MODEL setting has been removed - see django-cors-headers' HISTORY.",
-                id="corsheaders.E012"
+                (
+                    "The CORS_MODEL setting has been removed - see "
+                    + "django-cors-headers' HISTORY."
+                ),
+                id="corsheaders.E012",
             )
         )
 
@@ -126,7 +147,6 @@ def check_settings(app_configs, **kwargs):
 
 
 def is_sequence(thing, type_or_types):
-    return (
-        isinstance(thing, Sequence)
-        and all(isinstance(x, type_or_types) for x in thing)
+    return isinstance(thing, Sequence) and all(
+        isinstance(x, type_or_types) for x in thing
     )

--- a/corsheaders/conf.py
+++ b/corsheaders/conf.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
-from corsheaders.defaults import default_headers, default_methods  # Kept here for backwards compatibility
+# Kept here for backwards compatibility
+from corsheaders.defaults import default_headers, default_methods
 
 
 class Settings(object):
@@ -10,43 +11,43 @@ class Settings(object):
 
     @property
     def CORS_ALLOW_HEADERS(self):
-        return getattr(settings, 'CORS_ALLOW_HEADERS', default_headers)
+        return getattr(settings, "CORS_ALLOW_HEADERS", default_headers)
 
     @property
     def CORS_ALLOW_METHODS(self):
-        return getattr(settings, 'CORS_ALLOW_METHODS', default_methods)
+        return getattr(settings, "CORS_ALLOW_METHODS", default_methods)
 
     @property
     def CORS_ALLOW_CREDENTIALS(self):
-        return getattr(settings, 'CORS_ALLOW_CREDENTIALS', False)
+        return getattr(settings, "CORS_ALLOW_CREDENTIALS", False)
 
     @property
     def CORS_PREFLIGHT_MAX_AGE(self):
-        return getattr(settings, 'CORS_PREFLIGHT_MAX_AGE', 86400)
+        return getattr(settings, "CORS_PREFLIGHT_MAX_AGE", 86400)
 
     @property
     def CORS_ORIGIN_ALLOW_ALL(self):
-        return getattr(settings, 'CORS_ORIGIN_ALLOW_ALL', False)
+        return getattr(settings, "CORS_ORIGIN_ALLOW_ALL", False)
 
     @property
     def CORS_ORIGIN_WHITELIST(self):
-        return getattr(settings, 'CORS_ORIGIN_WHITELIST', ())
+        return getattr(settings, "CORS_ORIGIN_WHITELIST", ())
 
     @property
     def CORS_ORIGIN_REGEX_WHITELIST(self):
-        return getattr(settings, 'CORS_ORIGIN_REGEX_WHITELIST', ())
+        return getattr(settings, "CORS_ORIGIN_REGEX_WHITELIST", ())
 
     @property
     def CORS_EXPOSE_HEADERS(self):
-        return getattr(settings, 'CORS_EXPOSE_HEADERS', ())
+        return getattr(settings, "CORS_EXPOSE_HEADERS", ())
 
     @property
     def CORS_URLS_REGEX(self):
-        return getattr(settings, 'CORS_URLS_REGEX', r'^.*$')
+        return getattr(settings, "CORS_URLS_REGEX", r"^.*$")
 
     @property
     def CORS_REPLACE_HTTPS_REFERER(self):
-        return getattr(settings, 'CORS_REPLACE_HTTPS_REFERER', False)
+        return getattr(settings, "CORS_REPLACE_HTTPS_REFERER", False)
 
 
 conf = Settings()

--- a/corsheaders/defaults.py
+++ b/corsheaders/defaults.py
@@ -1,20 +1,13 @@
 default_headers = (
-    'accept',
-    'accept-encoding',
-    'authorization',
-    'content-type',
-    'dnt',
-    'origin',
-    'user-agent',
-    'x-csrftoken',
-    'x-requested-with',
+    "accept",
+    "accept-encoding",
+    "authorization",
+    "content-type",
+    "dnt",
+    "origin",
+    "user-agent",
+    "x-csrftoken",
+    "x-requested-with",
 )
 
-default_methods = (
-    'DELETE',
-    'GET',
-    'OPTIONS',
-    'PATCH',
-    'POST',
-    'PUT',
-)
+default_methods = ("DELETE", "GET", "OPTIONS", "PATCH", "POST", "PUT")

--- a/corsheaders/signals.py
+++ b/corsheaders/signals.py
@@ -3,4 +3,4 @@ from django.dispatch import Signal
 # If any attached handler returns Truthy, CORS will be allowed for the request.
 # This can be used to build custom logic into the request handling when the
 # configuration doesn't work.
-check_request_enabled = Signal(providing_args=['request'])
+check_request_enabled = Signal(providing_args=["request"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/requirements/py35-django111.txt
+++ b/requirements/py35-django111.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py35-django20.txt
+++ b/requirements/py35-django20.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py35-django21.txt
+++ b/requirements/py35-django21.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py35-django22.txt
+++ b/requirements/py35-django22.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django111.txt
+++ b/requirements/py36-django111.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django20.txt
+++ b/requirements/py36-django20.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django21.txt
+++ b/requirements/py36-django21.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django22.txt
+++ b/requirements/py36-django22.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,6 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37-django111.txt
+++ b/requirements/py37-django111.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -68,6 +79,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -155,6 +169,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django20.txt
+++ b/requirements/py37-django20.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -68,6 +79,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -155,6 +169,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django21.txt
+++ b/requirements/py37-django21.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -68,6 +79,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -155,6 +169,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django22.txt
+++ b/requirements/py37-django22.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -68,6 +79,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -155,6 +169,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,8 @@
+black ; python_version == '3.7.*'
 django
 docutils
 flake8
+flake8-bugbear
 isort
 multilint
 pytest

--- a/runtests.py
+++ b/runtests.py
@@ -6,9 +6,9 @@ import pytest
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
     return pytest.main()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,17 @@
 [flake8]
-ignore = X99999, W503, C901
-max-complexity = 12
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
+include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = corsheaders
 known_third_party = django
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -5,54 +5,52 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version(os.path.join('corsheaders', '__init__.py'))
+version = get_version(os.path.join("corsheaders", "__init__.py"))
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
+with open("HISTORY.rst", "r") as history_file:
     history = history_file.read()
 
 setup(
-    name='django-cors-headers',
+    name="django-cors-headers",
     version=version,
     description=(
-        'django-cors-headers is a Django application for handling the server '
-        'headers required for Cross-Origin Resource Sharing (CORS).'
+        "django-cors-headers is a Django application for handling the server "
+        "headers required for Cross-Origin Resource Sharing (CORS)."
     ),
-    long_description=readme + '\n\n' + history,
-    author='Otto Yiu',
-    author_email='otto@live.ca',
-    url='https://github.com/ottoyiu/django-cors-headers',
-    packages=['corsheaders'],
-    license='MIT License',
-    keywords=['django', 'cors', 'middleware', 'rest', 'api'],
-    install_requires=[
-        'Django>=1.11',
-    ],
-    python_requires='>=3.5',
+    long_description=readme + "\n\n" + history,
+    author="Otto Yiu",
+    author_email="otto@live.ca",
+    url="https://github.com/ottoyiu/django-cors-headers",
+    packages=["corsheaders"],
+    license="MIT License",
+    keywords=["django", "cors", "middleware", "rest", "api"],
+    install_requires=["Django>=1.11"],
+    python_requires=">=3.5",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Software Development :: Libraries :: Application Frameworks',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Software Development :: Libraries :: Application Frameworks",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,27 +1,15 @@
-SECRET_KEY = 'NOTASECRET'
+SECRET_KEY = "NOTASECRET"
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
-INSTALLED_APPS = [
-    'corsheaders',
-]
+INSTALLED_APPS = ["corsheaders"]
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-    },
-}
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    },
-]
+TEMPLATES = [{"BACKEND": "django.template.backends.django.DjangoTemplates"}]
 
-ROOT_URLCONF = 'tests.urls'
+ROOT_URLCONF = "tests.urls"
 
-MIDDLEWARE = [
-    'corsheaders.middleware.CorsMiddleware',
-]
+MIDDLEWARE = ["corsheaders.middleware.CorsMiddleware"]
 
-SECURE_PROXY_SSL_HEADER = ('HTTP_FAKE_SECURE', 'true')
+SECURE_PROXY_SSL_HEADER = ("HTTP_FAKE_SECURE", "true")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -10,7 +10,6 @@ from corsheaders.checks import check_settings
 
 
 class ChecksTests(SimpleTestCase):
-
     def check_error_codes(self, expected):
         errors = check_settings([])
         assert len(errors) == len(expected)
@@ -21,93 +20,93 @@ class ChecksTests(SimpleTestCase):
         self.check_error_codes([])
 
     def test_defaults_pass_check(self):
-        call_command('check')
+        call_command("check")
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=object)
     def test_checks_are_bound(self):
         with pytest.raises(base.SystemCheckError):
-            call_command('check')
+            call_command("check")
 
     @override_settings(CORS_ALLOW_HEADERS=object)
     def test_cors_allow_headers_non_sequence(self):
-        self.check_error_codes(['corsheaders.E001'])
+        self.check_error_codes(["corsheaders.E001"])
 
     @override_settings(CORS_ALLOW_HEADERS=[object])
     def test_cors_allow_headers_non_string(self):
-        self.check_error_codes(['corsheaders.E001'])
+        self.check_error_codes(["corsheaders.E001"])
 
     @override_settings(CORS_ALLOW_METHODS=object)
     def test_cors_allow_methods_non_sequence(self):
-        self.check_error_codes(['corsheaders.E002'])
+        self.check_error_codes(["corsheaders.E002"])
 
     @override_settings(CORS_ALLOW_METHODS=[object])
     def test_cors_allow_methods_non_string(self):
-        self.check_error_codes(['corsheaders.E002'])
+        self.check_error_codes(["corsheaders.E002"])
 
     @override_settings(CORS_ALLOW_CREDENTIALS=object)
     def test_cors_allow_credentials_non_bool(self):
-        self.check_error_codes(['corsheaders.E003'])
+        self.check_error_codes(["corsheaders.E003"])
 
-    @override_settings(CORS_PREFLIGHT_MAX_AGE='10')
+    @override_settings(CORS_PREFLIGHT_MAX_AGE="10")
     def test_cors_preflight_max_age_non_integer(self):
-        self.check_error_codes(['corsheaders.E004'])
+        self.check_error_codes(["corsheaders.E004"])
 
     @override_settings(CORS_PREFLIGHT_MAX_AGE=-1)
     def test_cors_preflight_max_age_negative(self):
-        self.check_error_codes(['corsheaders.E004'])
+        self.check_error_codes(["corsheaders.E004"])
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=object)
     def test_cors_origin_allow_all_non_bool(self):
-        self.check_error_codes(['corsheaders.E005'])
+        self.check_error_codes(["corsheaders.E005"])
 
     @override_settings(CORS_ORIGIN_WHITELIST=object)
     def test_cors_origin_whitelist_non_sequence(self):
-        self.check_error_codes(['corsheaders.E006'])
+        self.check_error_codes(["corsheaders.E006"])
 
     @override_settings(CORS_ORIGIN_WHITELIST=[object])
     def test_cors_origin_whitelist_non_string(self):
-        self.check_error_codes(['corsheaders.E006'])
+        self.check_error_codes(["corsheaders.E006"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com', 'null'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com", "null"])
     def test_cors_origin_whitelist_allowed(self):
         self.check_error_codes([])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['example.com'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["example.com"])
     def test_cors_origin_whitelist_no_scheme(self):
-        self.check_error_codes(['corsheaders.E013'])
+        self.check_error_codes(["corsheaders.E013"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['https://'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["https://"])
     def test_cors_origin_whitelist_no_netloc(self):
-        self.check_error_codes(['corsheaders.E013'])
+        self.check_error_codes(["corsheaders.E013"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['https://example.com/foobar'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["https://example.com/foobar"])
     def test_cors_origin_whitelist_path(self):
-        self.check_error_codes(['corsheaders.E014'])
+        self.check_error_codes(["corsheaders.E014"])
 
     @override_settings(CORS_ORIGIN_REGEX_WHITELIST=object)
     def test_cors_origin_regex_whitelist_non_sequence(self):
-        self.check_error_codes(['corsheaders.E007'])
+        self.check_error_codes(["corsheaders.E007"])
 
-    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=[re.compile(r'a')])
+    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=[re.compile(r"a")])
     def test_cors_origin_regex_whitelist_regex(self):
         self.check_error_codes([])
 
     @override_settings(CORS_EXPOSE_HEADERS=object)
     def test_cors_expose_headers_non_sequence(self):
-        self.check_error_codes(['corsheaders.E008'])
+        self.check_error_codes(["corsheaders.E008"])
 
     @override_settings(CORS_EXPOSE_HEADERS=[object])
     def test_cors_expose_headers_non_string(self):
-        self.check_error_codes(['corsheaders.E008'])
+        self.check_error_codes(["corsheaders.E008"])
 
     @override_settings(CORS_URLS_REGEX=object)
     def test_cors_urls_regex_non_string(self):
-        self.check_error_codes(['corsheaders.E009'])
+        self.check_error_codes(["corsheaders.E009"])
 
     @override_settings(CORS_REPLACE_HTTPS_REFERER=object)
     def test_cors_replace_https_referer_failure(self):
-        self.check_error_codes(['corsheaders.E011'])
+        self.check_error_codes(["corsheaders.E011"])
 
-    @override_settings(CORS_MODEL='something')
+    @override_settings(CORS_MODEL="something")
     def test_cors_model_failure(self):
-        self.check_error_codes(['corsheaders.E012'])
+        self.check_error_codes(["corsheaders.E012"])

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -5,7 +5,6 @@ from corsheaders.conf import conf
 
 
 class ConfTests(SimpleTestCase):
-
-    @override_settings(CORS_ALLOW_HEADERS=['foo'])
+    @override_settings(CORS_ALLOW_HEADERS=["foo"])
     def test_can_override(self):
-        assert conf.CORS_ALLOW_HEADERS == ['foo']
+        assert conf.CORS_ALLOW_HEADERS == ["foo"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,174 +4,163 @@ from django.test.utils import override_settings
 from django.utils.deprecation import MiddlewareMixin
 
 from corsheaders.middleware import (
-    ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
-    ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE
+    ACCESS_CONTROL_ALLOW_CREDENTIALS,
+    ACCESS_CONTROL_ALLOW_HEADERS,
+    ACCESS_CONTROL_ALLOW_METHODS,
+    ACCESS_CONTROL_ALLOW_ORIGIN,
+    ACCESS_CONTROL_EXPOSE_HEADERS,
+    ACCESS_CONTROL_MAX_AGE,
 )
-from tests.utils import append_middleware, prepend_middleware, temporary_check_request_hander
+from tests.utils import (
+    append_middleware,
+    prepend_middleware,
+    temporary_check_request_hander,
+)
 
 
 class ShortCircuitMiddleware(MiddlewareMixin):
-
     def process_request(self, request):
-        return HttpResponse('short-circuit-middleware-response')
+        return HttpResponse("short-circuit-middleware-response")
 
 
 class CorsMiddlewareTests(TestCase):
-
     def test_get_no_origin(self):
-        resp = self.client.get('/')
+        resp = self.client.get("/")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     def test_get_origin_vary_by_default(self):
-        resp = self.client.get('/')
-        assert resp['Vary'] == 'Origin'
+        resp = self.client.get("/")
+        assert resp["Vary"] == "Origin"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
     def test_get_not_in_whitelist(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.org')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.org")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['https://example.org'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["https://example.org"])
     def test_get_not_in_whitelist_due_to_wrong_scheme(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.org')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.org")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com', 'http://example.org'])
+    @override_settings(
+        CORS_ORIGIN_WHITELIST=["http://example.com", "http://example.org"]
+    )
     def test_get_in_whitelist(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.org')
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.org'
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.org")
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.org"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com', 'null'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com", "null"])
     def test_null_in_whitelist(self):
-        resp = self.client.get('/', HTTP_ORIGIN='null')
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'null'
+        resp = self.client.get("/", HTTP_ORIGIN="null")
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "null"
 
     @override_settings(
         CORS_ORIGIN_ALLOW_ALL=True,
-        CORS_EXPOSE_HEADERS=['accept', 'origin', 'content-type'],
+        CORS_EXPOSE_HEADERS=["accept", "origin", "content-type"],
     )
     def test_get_expose_headers(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
-        assert resp[ACCESS_CONTROL_EXPOSE_HEADERS] == 'accept, origin, content-type'
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
+        assert resp[ACCESS_CONTROL_EXPOSE_HEADERS] == "accept, origin, content-type"
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=True)
     def test_get_dont_expose_headers(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_EXPOSE_HEADERS not in resp
 
-    @override_settings(
-        CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_ALLOW_ALL=True,
-    )
+    @override_settings(CORS_ALLOW_CREDENTIALS=True, CORS_ORIGIN_ALLOW_ALL=True)
     def test_get_allow_credentials(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
-        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == 'true'
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
+        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == "true"
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=True)
     def test_get_dont_allow_credentials(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
 
     @override_settings(
-        CORS_ALLOW_HEADERS=['content-type', 'origin'],
-        CORS_ALLOW_METHODS=['GET', 'OPTIONS'],
+        CORS_ALLOW_HEADERS=["content-type", "origin"],
+        CORS_ALLOW_METHODS=["GET", "OPTIONS"],
         CORS_PREFLIGHT_MAX_AGE=1002,
         CORS_ORIGIN_ALLOW_ALL=True,
     )
     def test_options_allowed_origin(self):
-        resp = self.client.options(
-            '/',
-            HTTP_ORIGIN='http://example.com',
-        )
-        assert resp[ACCESS_CONTROL_ALLOW_HEADERS] == 'content-type, origin'
-        assert resp[ACCESS_CONTROL_ALLOW_METHODS] == 'GET, OPTIONS'
-        assert resp[ACCESS_CONTROL_MAX_AGE] == '1002'
+        resp = self.client.options("/", HTTP_ORIGIN="http://example.com")
+        assert resp[ACCESS_CONTROL_ALLOW_HEADERS] == "content-type, origin"
+        assert resp[ACCESS_CONTROL_ALLOW_METHODS] == "GET, OPTIONS"
+        assert resp[ACCESS_CONTROL_MAX_AGE] == "1002"
 
     @override_settings(
-        CORS_ALLOW_HEADERS=['content-type', 'origin'],
-        CORS_ALLOW_METHODS=['GET', 'OPTIONS'],
+        CORS_ALLOW_HEADERS=["content-type", "origin"],
+        CORS_ALLOW_METHODS=["GET", "OPTIONS"],
         CORS_PREFLIGHT_MAX_AGE=0,
         CORS_ORIGIN_ALLOW_ALL=True,
     )
     def test_options_no_max_age(self):
-        resp = self.client.options('/', HTTP_ORIGIN='http://example.com')
-        assert resp[ACCESS_CONTROL_ALLOW_HEADERS] == 'content-type, origin'
-        assert resp[ACCESS_CONTROL_ALLOW_METHODS] == 'GET, OPTIONS'
+        resp = self.client.options("/", HTTP_ORIGIN="http://example.com")
+        assert resp[ACCESS_CONTROL_ALLOW_HEADERS] == "content-type, origin"
+        assert resp[ACCESS_CONTROL_ALLOW_METHODS] == "GET, OPTIONS"
         assert ACCESS_CONTROL_MAX_AGE not in resp
 
     @override_settings(
-        CORS_ALLOW_METHODS=['OPTIONS'],
+        CORS_ALLOW_METHODS=["OPTIONS"],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_WHITELIST=['http://localhost:9000'],
+        CORS_ORIGIN_WHITELIST=["http://localhost:9000"],
     )
     def test_options_whitelist_with_port(self):
-        resp = self.client.options('/', HTTP_ORIGIN='http://localhost:9000')
-        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == 'true'
+        resp = self.client.options("/", HTTP_ORIGIN="http://localhost:9000")
+        assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == "true"
 
     @override_settings(
-        CORS_ALLOW_METHODS=['OPTIONS'],
+        CORS_ALLOW_METHODS=["OPTIONS"],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_REGEX_WHITELIST=[r'^http?://(\w+\.)?example\.com$'],
+        CORS_ORIGIN_REGEX_WHITELIST=[r"^http?://(\w+\.)?example\.com$"],
     )
     def test_options_adds_origin_when_domain_found_in_origin_regex_whitelist(self):
-        resp = self.client.options('/', HTTP_ORIGIN='http://foo.example.com')
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://foo.example.com'
+        resp = self.client.options("/", HTTP_ORIGIN="http://foo.example.com")
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://foo.example.com"
 
     @override_settings(
-        CORS_ALLOW_METHODS=['OPTIONS'],
+        CORS_ALLOW_METHODS=["OPTIONS"],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_REGEX_WHITELIST=(r'^http?://(\w+\.)?example\.org$',),
+        CORS_ORIGIN_REGEX_WHITELIST=(r"^http?://(\w+\.)?example\.org$",),
     )
-    def test_options_will_not_add_origin_when_domain_not_found_in_origin_regex_whitelist(self):
-        resp = self.client.options('/', HTTP_ORIGIN='http://foo.example.com')
+    def test_options_will_not_add_origin_when_domain_not_found_in_origin_regex_whitelist(  # noqa: B950
+        self
+    ):
+        resp = self.client.options("/", HTTP_ORIGIN="http://foo.example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     def test_options(self):
-        resp = self.client.options(
-            '/',
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
-        )
+        resp = self.client.options("/", HTTP_ACCESS_CONTROL_REQUEST_METHOD="value")
         assert resp.status_code == 200
 
     def test_options_empty_request_method(self):
-        resp = self.client.options(
-            '/',
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD='',
-        )
+        resp = self.client.options("/", HTTP_ACCESS_CONTROL_REQUEST_METHOD="")
         assert resp.status_code == 200
 
     def test_options_no_header(self):
-        resp = self.client.options('/')
+        resp = self.client.options("/")
         assert resp.status_code == 404
 
-    @override_settings(
-        CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_ALLOW_ALL=True,
-    )
+    @override_settings(CORS_ALLOW_CREDENTIALS=True, CORS_ORIGIN_ALLOW_ALL=True)
     def test_allow_all_origins_get(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert resp.status_code == 200
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
-        assert resp['Vary'] == 'Origin'
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.com"
+        assert resp["Vary"] == "Origin"
 
-    @override_settings(
-        CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_ALLOW_ALL=True,
-    )
+    @override_settings(CORS_ALLOW_CREDENTIALS=True, CORS_ORIGIN_ALLOW_ALL=True)
     def test_allow_all_origins_options(self):
         resp = self.client.options(
-            '/',
-            HTTP_ORIGIN='http://example.com',
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+            "/",
+            HTTP_ORIGIN="http://example.com",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="value",
         )
         assert resp.status_code == 200
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
-        assert resp['Vary'] == 'Origin'
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.com"
+        assert resp["Vary"] == "Origin"
 
-    @override_settings(
-        CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_ALLOW_ALL=True,
-    )
+    @override_settings(CORS_ALLOW_CREDENTIALS=True, CORS_ORIGIN_ALLOW_ALL=True)
     def test_non_200_headers_still_set(self):
         """
         It's not clear whether the header should still be set for non-HTTP200
@@ -179,29 +168,26 @@ class CorsMiddlewareTests(TestCase):
         django-cors-middleware, so at least this test makes that explicit, especially
         since for the switch to Django 1.10, special-handling will need to be put in
         place to preserve this behaviour. See `ExceptionMiddleware` mention here:
-        https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+        https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware  # noqa: B950
         """
-        resp = self.client.get('/test-401/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/test-401/", HTTP_ORIGIN="http://example.com")
         assert resp.status_code == 401
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.com"
 
-    @override_settings(
-        CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_ALLOW_ALL=True,
-    )
+    @override_settings(CORS_ALLOW_CREDENTIALS=True, CORS_ORIGIN_ALLOW_ALL=True)
     def test_auth_view_options(self):
         """
         Ensure HTTP200 and header still set, for preflight requests to views requiring
         authentication. See: https://github.com/ottoyiu/django-cors-headers/issues/3
         """
         resp = self.client.options(
-            '/test-401/',
-            HTTP_ORIGIN='http://example.com',
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+            "/test-401/",
+            HTTP_ORIGIN="http://example.com",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="value",
         )
         assert resp.status_code == 200
-        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
-        assert resp['Content-Length'] == '0'
+        assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.com"
+        assert resp["Content-Length"] == "0"
 
     def test_signal_handler_that_returns_false(self):
         def handler(*args, **kwargs):
@@ -209,9 +195,9 @@ class CorsMiddlewareTests(TestCase):
 
         with temporary_check_request_hander(handler):
             resp = self.client.options(
-                '/',
-                HTTP_ORIGIN='http://example.com',
-                HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+                "/",
+                HTTP_ORIGIN="http://example.com",
+                HTTP_ACCESS_CONTROL_REQUEST_METHOD="value",
             )
 
             assert resp.status_code == 200
@@ -223,49 +209,50 @@ class CorsMiddlewareTests(TestCase):
 
         with temporary_check_request_hander(handler):
             resp = self.client.options(
-                '/',
-                HTTP_ORIGIN='http://example.com',
-                HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+                "/",
+                HTTP_ORIGIN="http://example.com",
+                HTTP_ACCESS_CONTROL_REQUEST_METHOD="value",
             )
             assert resp.status_code == 200
-            assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.com'
+            assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.com"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
     def test_signal_handler_allow_some_urls_to_everyone(self):
         def allow_api_to_all(sender, request, **kwargs):
-            return request.path.startswith('/api/')
+            return request.path.startswith("/api/")
 
         with temporary_check_request_hander(allow_api_to_all):
             resp = self.client.options(
-                '/',
-                HTTP_ORIGIN='http://example.org',
-                HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+                "/",
+                HTTP_ORIGIN="http://example.org",
+                HTTP_ACCESS_CONTROL_REQUEST_METHOD="value",
             )
             assert resp.status_code == 200
             assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
             resp = self.client.options(
-                '/api/something/',
-                HTTP_ORIGIN='http://example.org',
-                HTTP_ACCESS_CONTROL_REQUEST_METHOD='value',
+                "/api/something/",
+                HTTP_ORIGIN="http://example.org",
+                HTTP_ACCESS_CONTROL_REQUEST_METHOD="value",
             )
             assert resp.status_code == 200
-            assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == 'http://example.org'
+            assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.org"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
     def test_signal_called_once_during_normal_flow(self):
         def allow_all(sender, request, **kwargs):
             allow_all.calls += 1
             return True
+
         allow_all.calls = 0
 
         with temporary_check_request_hander(allow_all):
-            self.client.get('/', HTTP_ORIGIN='http://example.org')
+            self.client.get("/", HTTP_ORIGIN="http://example.org")
 
             assert allow_all.calls == 1
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com'])
-    @prepend_middleware('tests.test_middleware.ShortCircuitMiddleware')
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
+    @prepend_middleware("tests.test_middleware.ShortCircuitMiddleware")
     def test_get_short_circuit(self):
         """
         Test a scenario when a middleware that returns a response is run before
@@ -273,152 +260,147 @@ class CorsMiddlewareTests(TestCase):
         ``CorsMiddleware.process_response()`` should ignore the request if
         MIDDLEWARE setting is used (new mechanism in Django 1.10+).
         """
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=['http://example.com'],
-        CORS_URLS_REGEX=r'^/foo/$',
+        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
     )
-    @prepend_middleware(__name__ + '.ShortCircuitMiddleware')
+    @prepend_middleware(__name__ + ".ShortCircuitMiddleware")
     def test_get_short_circuit_should_be_ignored(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=['http://example.com'],
-        CORS_URLS_REGEX=r'^/foo/$',
+        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
     )
     def test_get_regex_matches(self):
-        resp = self.client.get('/foo/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/foo/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=['http://example.com'],
-        CORS_URLS_REGEX=r'^/not-foo/$',
+        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/not-foo/$"
     )
     def test_get_regex_doesnt_match(self):
-        resp = self.client.get('/foo/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/foo/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=['http://example.com'],
-        CORS_URLS_REGEX=r'^/foo/$',
+        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
     )
     def test_get_regex_matches_path_info(self):
-        resp = self.client.get('/foo/', HTTP_ORIGIN='http://example.com', SCRIPT_NAME='/prefix/')
+        resp = self.client.get(
+            "/foo/", HTTP_ORIGIN="http://example.com", SCRIPT_NAME="/prefix/"
+        )
         assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
     def test_cors_enabled_is_attached_and_bool(self):
         """
         Ensure that request._cors_enabled is available - although a private API
         someone might use it for debugging
         """
-        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         request = resp.wsgi_request
         assert isinstance(request._cors_enabled, bool)
         assert request._cors_enabled
 
-    @override_settings(CORS_ORIGIN_WHITELIST=['http://example.com'])
+    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
     def test_works_if_view_deletes_cors_enabled(self):
         """
         Just in case something crazy happens in the view or other middleware,
         check that get_response doesn't fall over if `_cors_enabled` is removed
         """
-        resp = self.client.get(
-            '/delete-is-enabled/',
-            HTTP_ORIGIN='http://example.com',
-        )
+        resp = self.client.get("/delete-is-enabled/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
 
 
 @override_settings(
-    CORS_REPLACE_HTTPS_REFERER=True,
-    CORS_ORIGIN_REGEX_WHITELIST=(r'.*example.*',),
+    CORS_REPLACE_HTTPS_REFERER=True, CORS_ORIGIN_REGEX_WHITELIST=(r".*example.*",)
 )
 class RefererReplacementCorsMiddlewareTests(TestCase):
-
     def test_get_replaces_referer_when_secure(self):
         resp = self.client.get(
-            '/',
-            HTTP_FAKE_SECURE='true',
-            HTTP_HOST='example.com',
-            HTTP_ORIGIN='https://example.org',
-            HTTP_REFERER='https://example.org/foo'
+            "/",
+            HTTP_FAKE_SECURE="true",
+            HTTP_HOST="example.com",
+            HTTP_ORIGIN="https://example.org",
+            HTTP_REFERER="https://example.org/foo",
         )
         assert resp.status_code == 200
-        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.com/'
-        assert resp.wsgi_request.META['ORIGINAL_HTTP_REFERER'] == 'https://example.org/foo'
+        assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.com/"
+        assert (
+            resp.wsgi_request.META["ORIGINAL_HTTP_REFERER"] == "https://example.org/foo"
+        )
 
-    @append_middleware('corsheaders.middleware.CorsPostCsrfMiddleware')
+    @append_middleware("corsheaders.middleware.CorsPostCsrfMiddleware")
     def test_get_post_middleware_rereplaces_referer_when_secure(self):
         resp = self.client.get(
-            '/',
-            HTTP_FAKE_SECURE='true',
-            HTTP_HOST='example.com',
-            HTTP_ORIGIN='https://example.org',
-            HTTP_REFERER='https://example.org/foo'
+            "/",
+            HTTP_FAKE_SECURE="true",
+            HTTP_HOST="example.com",
+            HTTP_ORIGIN="https://example.org",
+            HTTP_REFERER="https://example.org/foo",
         )
         assert resp.status_code == 200
-        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.org/foo'
-        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+        assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.org/foo"
+        assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META
 
     def test_get_does_not_replace_referer_when_insecure(self):
         resp = self.client.get(
-            '/',
-            HTTP_HOST='example.com',
-            HTTP_ORIGIN='https://example.org',
-            HTTP_REFERER='https://example.org/foo'
+            "/",
+            HTTP_HOST="example.com",
+            HTTP_ORIGIN="https://example.org",
+            HTTP_REFERER="https://example.org/foo",
         )
         assert resp.status_code == 200
-        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.org/foo'
-        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+        assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.org/foo"
+        assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META
 
     @override_settings(CORS_REPLACE_HTTPS_REFERER=False)
     def test_get_does_not_replace_referer_when_disabled(self):
         resp = self.client.get(
-            '/',
-            HTTP_FAKE_SECURE='true',
-            HTTP_HOST='example.com',
-            HTTP_ORIGIN='https://example.org',
-            HTTP_REFERER='https://example.org/foo',
+            "/",
+            HTTP_FAKE_SECURE="true",
+            HTTP_HOST="example.com",
+            HTTP_ORIGIN="https://example.org",
+            HTTP_REFERER="https://example.org/foo",
         )
         assert resp.status_code == 200
-        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.org/foo'
-        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+        assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.org/foo"
+        assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META
 
     def test_get_does_not_fail_in_referer_replacement_when_referer_missing(self):
         resp = self.client.get(
-            '/',
-            HTTP_FAKE_SECURE='true',
-            HTTP_HOST='example.com',
-            HTTP_ORIGIN='https://example.org',
+            "/",
+            HTTP_FAKE_SECURE="true",
+            HTTP_HOST="example.com",
+            HTTP_ORIGIN="https://example.org",
         )
         assert resp.status_code == 200
-        assert 'HTTP_REFERER' not in resp.wsgi_request.META
-        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+        assert "HTTP_REFERER" not in resp.wsgi_request.META
+        assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META
 
     def test_get_does_not_fail_in_referer_replacement_when_host_missing(self):
         resp = self.client.get(
-            '/',
-            HTTP_FAKE_SECURE='true',
-            HTTP_ORIGIN='https://example.org',
-            HTTP_REFERER='https://example.org/foo',
+            "/",
+            HTTP_FAKE_SECURE="true",
+            HTTP_ORIGIN="https://example.org",
+            HTTP_REFERER="https://example.org/foo",
         )
         assert resp.status_code == 200
-        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.org/foo'
-        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+        assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.org/foo"
+        assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META
 
     @override_settings(CORS_ORIGIN_REGEX_WHITELIST=())
     def test_get_does_not_replace_referer_when_not_valid_request(self):
         resp = self.client.get(
-            '/',
-            HTTP_FAKE_SECURE='true',
-            HTTP_HOST='example.com',
-            HTTP_ORIGIN='https://example.org',
-            HTTP_REFERER='https://example.org/foo',
+            "/",
+            HTTP_FAKE_SECURE="true",
+            HTTP_HOST="example.com",
+            HTTP_ORIGIN="https://example.org",
+            HTTP_REFERER="https://example.org/foo",
         )
         assert resp.status_code == 200
-        assert resp.wsgi_request.META['HTTP_REFERER'] == 'https://example.org/foo'
-        assert 'ORIGINAL_HTTP_REFERER' not in resp.wsgi_request.META
+        assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.org/foo"
+        assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,24 +3,24 @@ from django.http import Http404, HttpResponse
 
 
 def test_view(request):
-    if request.method != 'GET':
+    if request.method != "GET":
         raise Http404()
     return HttpResponse("Test view")
 
 
 def test_view_http401(request):
-    return HttpResponse('Unauthorized', status=401)
+    return HttpResponse("Unauthorized", status=401)
 
 
 def test_view_that_deletes_is_enabled(request):
-    if hasattr(request, '_cors_enabled'):
+    if hasattr(request, "_cors_enabled"):
         del request._cors_enabled
     return HttpResponse()
 
 
 urlpatterns = [
-    url(r'^$', test_view),
-    url(r'^foo/$', test_view),
-    url(r'^test-401/$', test_view_http401),
-    url(r'^delete-is-enabled/$', test_view_that_deletes_is_enabled),
+    url(r"^$", test_view),
+    url(r"^foo/$", test_view),
+    url(r"^test-401/$", test_view_http401),
+    url(r"^delete-is-enabled/$", test_view_that_deletes_is_enabled),
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,19 +6,15 @@ from corsheaders.signals import check_request_enabled
 
 
 def add_middleware(action, path):
-    return modify_settings(**{
-        'MIDDLEWARE': {
-            action: path,
-        }
-    })
+    return modify_settings(**{"MIDDLEWARE": {action: path}})
 
 
 def append_middleware(path):
-    return add_middleware('append', path)
+    return add_middleware("append", path)
 
 
 def prepend_middleware(path):
-    return add_middleware('prepend', path)
+    return add_middleware("prepend", path)
 
 
 @contextmanager


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge